### PR TITLE
Add 5 Simtek F-16 instrument HSMs: 10-5859, 10-5860, 10-5862, 10-5866, 10-5868

### DIFF
--- a/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
+++ b/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
@@ -1,0 +1,264 @@
+using System;
+using System.IO;
+using System.Threading;
+using log4net;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Resilient file watcher for editor-authored gauge config files.
+    //
+    // Replaces the per-HSM FileSystemWatcher boilerplate with three layers
+    // of defence against the well-known Windows file-watching failure
+    // modes:
+    //
+    //   1. InternalBufferSize bumped to 64 KB (max safe value before the
+    //      kernel starts dropping events). Avoids transient buffer
+    //      overflows during bursty multi-gauge saves.
+    //
+    //   2. Error event handler. When the watcher reports an internal
+    //      error (most commonly buffer overflow), dispose the watcher
+    //      and create a fresh one on a background timer beat.
+    //
+    //   3. Periodic resubscribe (every 30 s). Several Windows scenarios
+    //      silently orphan a FileSystemWatcher without firing an Error
+    //      event — antivirus / OneDrive / SMB filter drivers can drop
+    //      the IOCP completion notifications mid-flight, leaving the
+    //      watcher object alive but deaf. Periodic recreation guarantees
+    //      the watcher is fresh at most every 30 s. Belt-and-braces.
+    //
+    //   4. Mtime poll fallback (every 5 s). Even if all three watcher
+    //      layers fail, a polling timer reads the file's
+    //      LastWriteTime and triggers a reload when it changes. This
+    //      guarantees worst-case ~5 s latency between editor save and
+    //      gauge reload, even when the watcher is completely broken.
+    //
+    // Per-HSM usage:
+    //
+    //     // In the HSM's field section
+    //     private ConfigFileReloadWatcher _configWatcher;
+    //
+    //     // In StartConfigWatcher (or equivalent)
+    //     _configWatcher = new ConfigFileReloadWatcher(
+    //         _config.FilePath, ReloadConfig);
+    //
+    //     // In Dispose
+    //     if (_configWatcher != null) {
+    //         _configWatcher.Dispose();
+    //         _configWatcher = null;
+    //     }
+    //
+    //     // The HSM's existing reload method:
+    //     private void ReloadConfig() {
+    //         var reloaded = MyHardwareSupportModuleConfig.Load(_config.FilePath);
+    //         if (reloaded == null) return;
+    //         reloaded.FilePath = _config.FilePath;
+    //         _config = reloaded;
+    //         ResolveAllChannels(reloaded);
+    //     }
+    //
+    // The helper handles all dedup internally; the HSM's onChange callback
+    // can assume the file actually changed since the last call.
+    public sealed class ConfigFileReloadWatcher : IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(ConfigFileReloadWatcher));
+
+        // 30 s resubscribe and 5 s poll cadence picked as a compromise:
+        // fast enough that a "watcher silently died" scenario heals in
+        // about as long as it takes the user to retry a save, slow
+        // enough to cost ~negligible CPU when nothing is happening.
+        private const int RESUBSCRIBE_INTERVAL_MS = 30 * 1000;
+        private const int POLL_INTERVAL_MS = 5 * 1000;
+        private const int INTERNAL_BUFFER_SIZE = 64 * 1024;  // 64 KB max safe
+
+        private readonly string _filePath;
+        private readonly Action _onChange;
+        private readonly object _lock = new object();
+
+        private FileSystemWatcher _watcher;
+        private Timer _resubscribeTimer;
+        private Timer _pollTimer;
+        private DateTime _lastSeenWriteTime = DateTime.MinValue;
+        private bool _isDisposed;
+
+        public ConfigFileReloadWatcher(string filePath, Action onChange)
+        {
+            if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException("filePath");
+            if (onChange == null) throw new ArgumentNullException("onChange");
+            _filePath = filePath;
+            _onChange = onChange;
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    _lastSeenWriteTime = File.GetLastWriteTimeUtc(_filePath);
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Warn("Could not read initial mtime for " + _filePath + ": " + e.Message);
+            }
+            CreateWatcher();
+            // Resubscribe periodically to recover from silent orphaning.
+            _resubscribeTimer = new Timer(
+                _ => RecreateWatcher(reason: "periodic"),
+                state: null,
+                dueTime: RESUBSCRIBE_INTERVAL_MS,
+                period: RESUBSCRIBE_INTERVAL_MS);
+            // Poll mtime as a worst-case fallback.
+            _pollTimer = new Timer(
+                _ => PollOnce(),
+                state: null,
+                dueTime: POLL_INTERVAL_MS,
+                period: POLL_INTERVAL_MS);
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                if (_resubscribeTimer != null)
+                {
+                    try { _resubscribeTimer.Dispose(); } catch { }
+                    _resubscribeTimer = null;
+                }
+                if (_pollTimer != null)
+                {
+                    try { _pollTimer.Dispose(); } catch { }
+                    _pollTimer = null;
+                }
+                DisposeWatcher();
+            }
+        }
+
+        // Called from constructor and RecreateWatcher. Caller must hold
+        // the lock when entering from RecreateWatcher; constructor is
+        // single-threaded so it doesn't need to.
+        private void CreateWatcher()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                var name = Path.GetFileName(_filePath);
+                if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name)) return;
+                if (!Directory.Exists(dir)) return;
+                var w = new FileSystemWatcher(dir, name)
+                {
+                    InternalBufferSize = INTERNAL_BUFFER_SIZE,
+                    NotifyFilter = NotifyFilters.LastWrite
+                                 | NotifyFilters.Size
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.CreationTime,
+                };
+                // Watch all the events that can signal a save: Changed for
+                // in-place truncate-write (Node fs.writeFileSync), Created
+                // for atomic-replace patterns (rename-into-place), and
+                // Renamed for editors that use a temp file then rename.
+                w.Changed += OnFsEvent;
+                w.Created += OnFsEvent;
+                w.Renamed += OnFsRenamed;
+                w.Error += OnFsError;
+                w.EnableRaisingEvents = true;
+                _watcher = w;
+            }
+            catch (Exception e)
+            {
+                _log.Error("Could not create FileSystemWatcher for " + _filePath + ": " + e.Message, e);
+            }
+        }
+
+        private void DisposeWatcher()
+        {
+            var w = _watcher;
+            _watcher = null;
+            if (w == null) return;
+            try { w.EnableRaisingEvents = false; } catch { }
+            try { w.Changed -= OnFsEvent; } catch { }
+            try { w.Created -= OnFsEvent; } catch { }
+            try { w.Renamed -= OnFsRenamed; } catch { }
+            try { w.Error -= OnFsError; } catch { }
+            try { w.Dispose(); } catch { }
+        }
+
+        private void RecreateWatcher(string reason)
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                DisposeWatcher();
+                CreateWatcher();
+            }
+            // After recreating, also poll once in case the file changed
+            // during the brief window where we had no watcher armed.
+            PollOnce();
+        }
+
+        private void OnFsEvent(object sender, FileSystemEventArgs e)
+        {
+            MaybeFireReload();
+        }
+
+        private void OnFsRenamed(object sender, RenamedEventArgs e)
+        {
+            // Atomic-replace patterns rename the new file INTO the watched
+            // name, so the rename event signals a fresh file is in place.
+            MaybeFireReload();
+        }
+
+        private void OnFsError(object sender, ErrorEventArgs e)
+        {
+            // Most common cause: internal buffer overflow. Dispose and
+            // recreate the watcher; the poll timer will catch any
+            // mtime change that happened between events.
+            var ex = e.GetException();
+            _log.Warn("FileSystemWatcher error for " + _filePath +
+                ": " + (ex != null ? ex.Message : "unknown") +
+                " — recreating watcher");
+            RecreateWatcher(reason: "error");
+        }
+
+        private void PollOnce()
+        {
+            if (_isDisposed) return;
+            MaybeFireReload();
+        }
+
+        // Single source of truth for "should we tell the HSM to reload?"
+        // Compares the file's current LastWriteTimeUtc against the last
+        // value we successfully reloaded for. Returns early when nothing
+        // has changed. Synchronised so multiple watcher events firing
+        // close together (or a watcher event arriving the same instant
+        // the poll timer ticks) collapse into a single reload.
+        private void MaybeFireReload()
+        {
+            DateTime now;
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                try
+                {
+                    if (!File.Exists(_filePath)) return;
+                    now = File.GetLastWriteTimeUtc(_filePath);
+                }
+                catch
+                {
+                    return;
+                }
+                if (now == _lastSeenWriteTime) return;
+                _lastSeenWriteTime = now;
+            }
+            // Invoke the HSM's reload callback OUTSIDE the lock so a slow
+            // reload (XML parse + channel re-resolve) doesn't block other
+            // threads that want to fire events while we're working.
+            try
+            {
+                _onChange();
+            }
+            catch (Exception e)
+            {
+                _log.Error("Reload callback failed for " + _filePath + ": " + e.Message, e);
+            }
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -1,0 +1,538 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Shared base for per-gauge calibration configs authored by the SimLinkup
+    // Profile Editor. Each gauge HSM that opts in derives a thin subclass with
+    // [XmlRoot(nameof(<TheModule>))] so the on-disk root element name matches
+    // the gauge HSM class name (matches the existing Simtek100285 / Simtek100294
+    // precedent — and what the editor writes).
+    //
+    // Schema (matches the editor's gauge-config-io.js round-trip):
+    //   <YourModuleName>
+    //     <Channels>
+    //       <Channel id="<HSM-port-id>">
+    //         <Transform kind="piecewise|linear|resolver|multi_resolver|cross_coupled">
+    //           <Breakpoints>             <!-- piecewise only -->
+    //             <Point input="..." volts="..."/>
+    //             ...
+    //           </Breakpoints>
+    //         </Transform>
+    //         <ZeroTrimVolts>0</ZeroTrimVolts>
+    //         <GainTrim>1</GainTrim>
+    //         <CoupledTo>...</CoupledTo>  <!-- cross_coupled only, optional -->
+    //       </Channel>
+    //     </Channels>
+    //   </YourModuleName>
+    //
+    // Today only the 'piecewise' kind is honoured by SimLinkup's gauge HSMs;
+    // the others round-trip safely so files survive future schema growth.
+    [Serializable]
+    public class GaugeCalibrationConfig
+    {
+        [XmlArray("Channels")]
+        [XmlArrayItem("Channel")]
+        public GaugeChannelConfig[] Channels { get; set; }
+
+        // Set by GetInstances after Load() so the gauge HSM's FileSystemWatcher
+        // knows which file to watch for hot-reload. [XmlIgnore] keeps it out of
+        // the round-trip (matches the ArduinoSeatHardwareSupportModuleConfig
+        // precedent).
+        [XmlIgnore]
+        public string FilePath { get; set; }
+
+        // Find a channel by its HSM port Id. Returns null when not present —
+        // gauge HSMs treat that as "no override; use hardcoded behaviour."
+        public GaugeChannelConfig FindChannel(string id)
+        {
+            if (Channels == null || string.IsNullOrEmpty(id)) return null;
+            return Channels.FirstOrDefault(c => c != null && c.Id == id);
+        }
+
+        // Generic loader. The caller passes T = derived per-gauge subclass and
+        // gets a strongly-typed result back. Safe to call when the file is
+        // absent — returns null in that case (callers fall back to hardcoded
+        // behaviour, matching the 10-0285 / 10-0294 precedent).
+        //
+        // Hot-reload-safe: this loader is what every editor-authored gauge
+        // config flows through, both at SimLinkup startup AND on every
+        // FileSystemWatcher Changed event. The watcher path races the
+        // editor's writer — the SimLinkup Profile Editor saves via Node's
+        // fs.writeFileSync, which on Windows triggers Changed events both
+        // when the file is truncated (size 0, XmlSerializer fails because
+        // the document is empty) AND when content is fully written. The
+        // first event arrives mid-write; without retries the watcher's
+        // change handler bails on it and the dedup mtime check skips
+        // subsequent events because LastWriteTime didn't change between
+        // truncate and write-complete on the same save. We close that
+        // race two ways:
+        //   1. Open the file with FileShare.ReadWrite so a writer holding
+        //      the file with default sharing doesn't lock us out
+        //      ("being used by another process" IOException).
+        //   2. Retry on transient failures (IOException + the
+        //      InvalidOperationException XmlSerializer throws on partial
+        //      documents) — 6 attempts × 50ms = ~300ms total, which
+        //      comfortably covers Node's writeFileSync window.
+        //
+        // Startup reads (no concurrent writer) hit the first attempt and
+        // return immediately, so this is free for the common case.
+        public static T Load<T>(string filePath) where T : GaugeCalibrationConfig
+        {
+            return Load<T>(filePath, attempts: 6, delayMs: 50);
+        }
+
+        public static T Load<T>(string filePath, int attempts, int delayMs) where T : GaugeCalibrationConfig
+        {
+            if (filePath == null) throw new ArgumentNullException("filePath");
+            if (!System.IO.File.Exists(filePath)) return default(T);
+            if (attempts < 1) attempts = 1;
+            Exception last = null;
+            var serializer = new XmlSerializer(typeof(T));
+            for (var i = 0; i < attempts; i++)
+            {
+                try
+                {
+                    using (var fs = new System.IO.FileStream(
+                        filePath,
+                        System.IO.FileMode.Open,
+                        System.IO.FileAccess.Read,
+                        System.IO.FileShare.ReadWrite))
+                    {
+                        return (T)serializer.Deserialize(fs);
+                    }
+                }
+                catch (System.IO.IOException e)
+                {
+                    last = e;  // editor's writer still holds the file — retry
+                }
+                catch (System.InvalidOperationException e)
+                {
+                    last = e;  // XmlSerializer hit a partial / empty file — retry
+                }
+                if (i + 1 < attempts && delayMs > 0)
+                {
+                    System.Threading.Thread.Sleep(delayMs);
+                }
+            }
+            // All retries exhausted; surface the last error so the caller's
+            // catch (every change-handler we've written) logs it.
+            if (last != null) throw last;
+            return default(T);
+        }
+
+        // Mirror of Save in the existing Simtek100285HardwareSupportModuleConfig
+        // precedent. Not used by SimLinkup itself today (the editor authors the
+        // file); included for symmetry and potential future round-trip tooling.
+        public void Save(string filePath)
+        {
+            Common.Serialization.Util.SerializeToXmlFile(this, filePath);
+        }
+    }
+
+    // Per-channel record. Distinguished by `Id` (matches the gauge HSM port
+    // signal Id, e.g. "100207_RPM_To_Instrument").
+    [Serializable]
+    public class GaugeChannelConfig
+    {
+        // The HSM output port Id this channel calibrates. Required.
+        [XmlAttribute("id")]
+        public string Id { get; set; }
+
+        // Transform record describing how input → volts is computed.
+        // Optional: when absent (or kind is unknown), gauge HSMs fall back to
+        // their hardcoded behaviour and still apply ZeroTrim/Gain on top.
+        [XmlElement("Transform")]
+        public GaugeTransformConfig Transform { get; set; }
+
+        // Per-channel zero-volt offset added to the computed transform output
+        // before the ±10 V clamp. 0 by default. Useful for trimming the gauge's
+        // physical needle zero point without changing the breakpoint table.
+        // Implemented as a nullable so we can distinguish "explicitly 0 in
+        // file" from "absent in file"; both behave the same way at runtime
+        // (additive offset of 0 is a no-op), but this lets future tooling
+        // tell the difference.
+        [XmlElement("ZeroTrimVolts")]
+        public double? ZeroTrimVolts { get; set; }
+
+        // Per-channel gain multiplier applied to the transform output before
+        // the ZeroTrim. 1.0 by default (unity). Useful for trimming full-scale
+        // span without re-tabulating breakpoints. Same nullable semantics as
+        // ZeroTrimVolts.
+        [XmlElement("GainTrim")]
+        public double? GainTrim { get; set; }
+
+        // Names another channel this one is computed from (cross_coupled).
+        // Round-trip-only today — SimLinkup's gauge HSMs don't yet act on it.
+        [XmlElement("CoupledTo")]
+        public string CoupledTo { get; set; }
+
+        // For digital_invert channels: whether the digital output is the
+        // logical inverse of the input. Defaults to false when absent. The
+        // 10-1084 ADI OFF flag uses this — its input is "OFF Flag Visible
+        // (1=visible)" and output is "OFF Flag Hidden (1=hidden)".
+        [XmlElement("Invert")]
+        public bool? Invert { get; set; }
+
+        // Caged-rest behaviour for standby ADI resolver pairs (pitch / roll
+        // SIN side carries these on each pair). When the gauge's OFF flag
+        // input is TRUE, the gauge's gimbal is mechanically caged — the
+        // gyro is at rest at whatever orientation it was in when last spun
+        // down, which is effectively random per power-cycle. The HSM picks
+        // a random angle in [Min, Max] degrees ONCE at construction time
+        // and drives sin/cos × PeakVolts to that angle for as long as the
+        // OFF flag stays TRUE. When the OFF flag goes FALSE (gauge spun
+        // up + uncaged), the HSM reverts to the configured piecewise
+        // transform and follows the input normally.
+        //
+        // Opt-in via CagedRestEnabled. Defaults to disabled (false / null)
+        // so existing profiles keep their pre-feature behaviour: when the
+        // OFF flag is visible the HSM continues to follow pitch/roll
+        // input regardless. Users who want the random rest behaviour
+        // enable it per gauge in the editor's Calibration tab.
+        //
+        // Only honoured by HSMs that opt in at the C# level (today:
+        // 10-0335-01 and 10-1084 standby ADIs, on their pitch and roll
+        // SIN channels). Editor defaults: pitch ±20°, roll ±40°. Set
+        // both Min and Max to the same value for a fixed (non-random)
+        // rest angle.
+        [XmlElement("CagedRestEnabled")]
+        public bool? CagedRestEnabled { get; set; }
+
+        [XmlElement("CagedRestRangeMinDegrees")]
+        public double? CagedRestRangeMinDegrees { get; set; }
+
+        [XmlElement("CagedRestRangeMaxDegrees")]
+        public double? CagedRestRangeMaxDegrees { get; set; }
+
+        // Apply ZeroTrim + GainTrim to a computed voltage, then clamp to
+        // [outputMin, outputMax] — the gauge's real hardware safe envelope
+        // (e.g. Westin EPU is 0.1..2.0 V, not the universal ±10 V). Callers
+        // pass the matching output signal's MinValue/MaxValue. The output
+        // signal is the canonical source of truth for what voltage is safe
+        // to send to the physical gauge mechanism, so trim values that
+        // would push the output past those bounds get clipped at the
+        // boundary instead of damaging the hardware.
+        //
+        // Order: gain first, then offset, then per-gauge clamp (matches
+        // what users intuitively expect when they say "make full-scale 5%
+        // wider then nudge zero up by 0.1 V").
+        //
+        // If outputMin >= outputMax (degenerate / unset bounds), returns 0
+        // so the gauge is visibly dead instead of quietly damaged. An HSM
+        // that forgets to declare MinValue/MaxValue on its output signal
+        // gets noticed on day one of testing rather than later.
+        public double ApplyTrim(double volts, double outputMin, double outputMax)
+        {
+            if (!(outputMin < outputMax)) return 0;
+            var gain   = GainTrim.HasValue      ? GainTrim.Value      : 1.0;
+            var offset = ZeroTrimVolts.HasValue ? ZeroTrimVolts.Value : 0.0;
+            var v = volts * gain + offset;
+            if (v < outputMin) return outputMin;
+            if (v > outputMax) return outputMax;
+            return v;
+        }
+    }
+
+    [Serializable]
+    public class GaugeTransformConfig
+    {
+        // 'piecewise' | 'linear' | 'resolver' | 'multi_resolver' | 'cross_coupled'.
+        // 'piecewise', 'linear', and 'resolver' are honoured by gauge HSMs
+        // today; the others round-trip for forward compatibility.
+        [XmlAttribute("kind")]
+        public string Kind { get; set; }
+
+        // Resolver pairs: each gauge has TWO output channels (sin + cos) but
+        // they share one transform. To avoid duplicating the transform on
+        // disk, the SIN channel carries the full transform body (InputMin,
+        // InputMax, AngleMin/MaxDegrees, PeakVolts, BelowMinBehavior) and
+        // the COS channel carries an empty body with role="cos" plus a
+        // PartnerChannel attribute pointing to the SIN channel id. The HSM
+        // reads both channels but pulls transform parameters from whichever
+        // carries them (always the SIN side as the editor writes it).
+        //
+        // role: "sin" or "cos" — present only for kind="resolver".
+        [XmlAttribute("role")]
+        public string Role { get; set; }
+
+        // Channel id of the partner (sin↔cos) — only set when Role is "cos".
+        [XmlAttribute("partnerChannel")]
+        public string PartnerChannel { get; set; }
+
+        // Piecewise transform: ordered breakpoint table. Linear interpolation
+        // between adjacent points; below the first / above the last clamps.
+        [XmlArray("Breakpoints")]
+        [XmlArrayItem("Point")]
+        public GaugeBreakpoint[] Breakpoints { get; set; }
+
+        // Linear and resolver transforms: maps `InputMin → angleMin / -10 V`
+        // and `InputMax → angleMax / +10 V`, with hard clamps outside.
+        // Nullable so the round-trip distinguishes "absent in file" from
+        // "explicitly set to 0".
+        [XmlElement("InputMin")]
+        public double? InputMin { get; set; }
+
+        [XmlElement("InputMax")]
+        public double? InputMax { get; set; }
+
+        // Resolver-specific: angular sweep mapped to [InputMin, InputMax].
+        // Default sweep is 0..360° if absent.
+        [XmlElement("AngleMinDegrees")]
+        public double? AngleMinDegrees { get; set; }
+
+        [XmlElement("AngleMaxDegrees")]
+        public double? AngleMaxDegrees { get; set; }
+
+        // Resolver peak voltage: sin/cos × PeakVolts is the output. Defaults
+        // to 10 V when absent — matches the Simtek 10-1088 convention.
+        [XmlElement("PeakVolts")]
+        public double? PeakVolts { get; set; }
+
+        // Resolver: what to do when input falls below InputMin. "zero" sets
+        // both outputs to 0 V (rest position; what 10-1088 nozzle does).
+        // "clamp" projects at angleMin (continuous behaviour expected by e.g.
+        // compass-style gauges). Default "clamp" if absent.
+        [XmlElement("BelowMinBehavior")]
+        public string BelowMinBehavior { get; set; }
+
+        // Multi-turn resolver: number of input units per full sin/cos
+        // revolution. Used by altimeter-style gauges where the synchro
+        // wraps many times across the input range (10-1081 altimeter
+        // fine = 1000 ft/rev; 10-0285 altimeter fine = 4000 ft/rev,
+        // coarse = 100000 ft/rev). The runtime computes
+        //   angle = (input / unitsPerRevolution) × 360°
+        // then sin/cos × peakVolts. No InputMin/Max needed — the sweep
+        // is unbounded; sin/cos handle negative angles cleanly.
+        [XmlElement("UnitsPerRevolution")]
+        public double? UnitsPerRevolution { get; set; }
+    }
+
+    [Serializable]
+    public class GaugeBreakpoint
+    {
+        [XmlAttribute("input")]
+        public double Input { get; set; }
+
+        // For piecewise transforms whose output is in volts (32 of the 33
+        // calibratable gauges in the editor). Default is 0 V; the C# default
+        // of `double` is also 0, so a gauge config that uses `output=` for
+        // raw DAC counts won't accidentally pick up the wrong value here.
+        [XmlAttribute("volts")]
+        public double Volts { get; set; }
+
+        // For piecewise transforms whose output is in raw DAC counts rather
+        // than volts (Henkie F-16 fuel flow drives its 12-bit DAC directly
+        // over USB/PHCC, bypassing AnalogDevices). Editor writes
+        // <Point input="500" output="18"/> for these gauges. HSMs that drive
+        // a DAC directly read this; HSMs that drive AD channels read Volts.
+        [XmlAttribute("output")]
+        public double Output { get; set; }
+
+        // For piecewise_resolver transforms: reference angle (degrees) at
+        // this input. Used by ADI-style gauges where the synchro angle is a
+        // non-linear function of the sim input (e.g. ADI pitch — input
+        // pitch°, output reference angle that drives a sin/cos pair). The
+        // angle should be encoded MONOTONICALLY in the breakpoint table —
+        // values may exceed 360° to keep linear interpolation working
+        // across the 360°→0° wrap; the runtime applies % 360 before
+        // computing sin/cos.
+        [XmlAttribute("angle")]
+        public double Angle { get; set; }
+    }
+
+    // Pure helpers. Live on the config namespace so per-gauge HSMs only need
+    // one `using Common.HardwareSupport.Calibration;` to evaluate a config.
+    public static class GaugeTransform
+    {
+        // Linearly interpolate `input` across an ordered list of breakpoints.
+        // Below the first breakpoint clamps to the first volts; above the last
+        // clamps to the last volts (matches the C# if/else fallback shape used
+        // by every Simtek HSM today). Returns the clamped voltage in ±10 V
+        // (final clamp lives in ApplyTrim, but pre-clamping here protects
+        // against breakpoints the editor may have flagged amber but saved).
+        //
+        // O(n) scan — the largest breakpoint table is 43 entries (10-0194
+        // airspeed); per-tick gauge update is well below any real cost.
+        public static double EvaluatePiecewise(double input, GaugeBreakpoint[] breakpoints)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                // Defensive: malformed config falls back to 0 V. Caller should
+                // detect this via a separate "config valid?" check before
+                // routing to this helper, but if they don't, 0 V is the
+                // safest neutral output.
+                return 0;
+            }
+            if (input <= breakpoints[0].Input) return Clamp(breakpoints[0].Volts);
+            var last = breakpoints[breakpoints.Length - 1];
+            if (input >= last.Input) return Clamp(last.Volts);
+            for (var i = 1; i < breakpoints.Length; i++)
+            {
+                var hi = breakpoints[i];
+                if (input < hi.Input)
+                {
+                    var lo = breakpoints[i - 1];
+                    var span = hi.Input - lo.Input;
+                    if (span <= 0) return Clamp(lo.Volts);  // degenerate; pick the lower
+                    var t = (input - lo.Input) / span;
+                    return Clamp(lo.Volts + t * (hi.Volts - lo.Volts));
+                }
+            }
+            return Clamp(last.Volts);
+        }
+
+        // Linear range: maps inputMin → -10 V, inputMax → +10 V, with hard
+        // clamps outside the range. Defensive against degenerate ranges
+        // (inputMin >= inputMax — returns 0 V neutral). Used by linear-pattern
+        // gauges (EPU fuel, fuel quantity, cabin altimeter, etc.).
+        public static double EvaluateLinear(double input, double inputMin, double inputMax)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return 0;
+            if (input <= inputMin) return -10;
+            if (input >= inputMax) return  10;
+            var t = (input - inputMin) / span;
+            return Clamp(-10 + t * 20);
+        }
+
+        // Resolver pair: maps `input` linearly to an angle in
+        // [angleMinDegrees, angleMaxDegrees], then projects to (sin, cos) ×
+        // peakVolts. `belowMinBehavior` controls the underflow case:
+        //   "zero"  — both outputs at 0 V (rest position; nozzle uses this)
+        //   "clamp" — project at angleMin (continuous; default)
+        // Above InputMax always clamps to angleMax (matches the C# nozzle
+        // shape and is the only behaviour that makes sense for a bounded
+        // mechanical gauge — full-scale stop).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each (sin and cos windings calibrate separately).
+        public static double[] EvaluateResolver(
+            double input,
+            double inputMin, double inputMax,
+            double angleMinDegrees, double angleMaxDegrees,
+            double peakVolts,
+            string belowMinBehavior)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return new double[] { 0, 0 };
+            double angleDeg;
+            if (input < inputMin)
+            {
+                if (string.Equals(belowMinBehavior, "zero", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new double[] { 0, 0 };
+                }
+                angleDeg = angleMinDegrees;
+            }
+            else if (input > inputMax)
+            {
+                angleDeg = angleMaxDegrees;
+            }
+            else
+            {
+                var t = (input - inputMin) / span;
+                angleDeg = angleMinDegrees + t * (angleMaxDegrees - angleMinDegrees);
+            }
+            // Fully qualify System.Math — there's a Common.Math namespace in
+            // sibling projects that shadows the unqualified `Math` here even
+            // with `using System;` in scope (because Common.HardwareSupport.
+            // Calibration is in the same parent namespace tree).
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Multi-turn resolver: input → angle = (input / unitsPerRevolution)
+        // × 360°, then sin/cos × peakVolts. The synchro wraps cleanly across
+        // many revolutions (negative angles included) — sin/cos handle it
+        // mathematically without any modulo logic. Used by altimeter-style
+        // gauges (10-1081 fine = 1000 ft/rev; 10-0285 fine = 4000 ft/rev).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each.
+        public static double[] EvaluateMultiTurnResolver(
+            double input,
+            double unitsPerRevolution,
+            double peakVolts)
+        {
+            if (unitsPerRevolution == 0) return new double[] { 0, 0 };
+            var revolutions = input / unitsPerRevolution;
+            var angleDeg = revolutions * 360.0;
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Piecewise-then-resolver: linearly interpolate `input` across the
+        // breakpoint table (where each Point's `Angle` is the reference
+        // angle in degrees), then project to (sin, cos) × peakVolts. Used
+        // by ADI-style gauges where the synchro angle is a non-linear
+        // function of the sim input (10-1084 pitch is the founding case).
+        //
+        // The angle table should be MONOTONICALLY increasing — values may
+        // exceed 360° to keep linear interpolation working across the
+        // 360°→0° wrap; this helper applies % 360 before sin/cos so the
+        // wrap is invisible to the synchro hardware.
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each. Below the first breakpoint clamps to the
+        // first angle; above the last clamps to the last (matches the
+        // EvaluatePiecewise voltage-clamp shape).
+        public static double[] EvaluatePiecewiseResolver(
+            double input,
+            GaugeBreakpoint[] breakpoints,
+            double peakVolts)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                return new double[] { 0, 0 };
+            }
+            double angleDeg;
+            if (input <= breakpoints[0].Input)
+            {
+                angleDeg = breakpoints[0].Angle;
+            }
+            else
+            {
+                var last = breakpoints[breakpoints.Length - 1];
+                if (input >= last.Input)
+                {
+                    angleDeg = last.Angle;
+                }
+                else
+                {
+                    angleDeg = last.Angle;  // overwritten in the loop unless degenerate
+                    for (var i = 1; i < breakpoints.Length; i++)
+                    {
+                        var hi = breakpoints[i];
+                        if (input < hi.Input)
+                        {
+                            var lo = breakpoints[i - 1];
+                            var span = hi.Input - lo.Input;
+                            if (span <= 0) { angleDeg = lo.Angle; break; }
+                            var t = (input - lo.Input) / span;
+                            angleDeg = lo.Angle + t * (hi.Angle - lo.Angle);
+                            break;
+                        }
+                    }
+                }
+            }
+            var rad = (angleDeg % 360.0) * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        private static double Clamp(double v)
+        {
+            if (v < -10) return -10;
+            if (v >  10) return  10;
+            return v;
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
+    <Compile Include="Calibration\GaugeCalibrationConfig.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -39,6 +39,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105859HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105859HardwareSupportModule.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.Remoting;
+using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
+using Common.MacroProgramming;
+using Common.Math;
+using LightningGauges.Renderers.F16;
+using log4net;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    //Simtek 10-5859 F-16 Standby Attitude Indicator
+    // (pitch piecewise_resolver + roll piecewise_resolver)
+    //
+    // Per the spec sheet (PL20-5859, dwg 10-5859):
+    //   Drive type: DUAL DC SERVO
+    //   Signal input: 10 VDC × sin/cos of reference angle
+    //   Pitch table: 11 points 0°..±90° → 0..338.82° non-linearly
+    //   Roll table:  9 points 90°L..0..90°R → 270..90° linearly
+    //
+    // Modeled on Simtek101084HardwareSupportModule (the other F-16 standby
+    // ADI in the catalog). Both pitch and roll are encoded as
+    // piecewise_resolver — pitch is genuinely non-linear; roll is linear
+    // but expressed as a piecewise table for editor consistency and to
+    // give users the ability to correct local synchro drift.
+    //
+    // Renderer reuse: borrows IStandbyADI from 10-1084. The visual
+    // preview will look like the other standby ADI; calibration and
+    // signal routing are independent.
+    public class Simtek105859HardwareSupportModule : HardwareSupportModuleBase, IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Simtek105859HardwareSupportModule));
+        private readonly IStandbyADI _renderer = new StandbyADI();
+
+        // Editor-authored calibration. Two independent overrides:
+        //   - pitch (piecewise_resolver pair)
+        //   - roll  (piecewise_resolver pair)
+        // Each may be null independently — Update*OutputValues falls
+        // through to the hardcoded path for any unconfigured channel.
+        private Simtek105859HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _pitchTransform;
+        private GaugeChannelConfig _pitchSinChannel;
+        private GaugeChannelConfig _pitchCosChannel;
+        private GaugeTransformConfig _rollTransform;
+        private GaugeChannelConfig _rollSinChannel;
+        private GaugeChannelConfig _rollCosChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        private bool _isDisposed;
+
+        private AnalogSignal _pitchCosOutputSignal;
+        private AnalogSignal _pitchInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _pitchInputSignalChangedEventHandler;
+        private AnalogSignal _pitchSinOutputSignal;
+        private AnalogSignal _rollCosOutputSignal;
+        private AnalogSignal _rollInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _rollInputSignalChangedEventHandler;
+        private AnalogSignal _rollSinOutputSignal;
+
+        public Simtek105859HardwareSupportModule(Simtek105859HardwareSupportModuleConfig config)
+        {
+            _config = config;
+            ResolveAllChannels(config);
+            CreateInputSignals();
+            CreateOutputSignals();
+            CreateInputEventHandlers();
+            RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "105859_Pitch_SIN_To_Instrument",
+                "105859_Pitch_COS_To_Instrument",
+                out _pitchTransform, out _pitchSinChannel, out _pitchCosChannel);
+            ResolvePiecewiseResolverPair(config,
+                "105859_Roll_SIN_To_Instrument",
+                "105859_Roll_COS_To_Instrument",
+                out _rollTransform, out _rollSinChannel, out _rollCosChannel);
+        }
+
+        // SIN side carries the shared transform body (breakpoints + PeakVolts);
+        // COS side carries only its own per-channel trim. Returns null
+        // transform when the config doesn't carry a usable record; HSM falls
+        // back to the hardcoded path in that case.
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Simtek105859HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate both outputs with cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven loop won't fire until the
+                // simulator next pushes a new pitch or roll value.
+                UpdatePitchOutputValues();
+                UpdateRollOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        public override AnalogSignal[] AnalogInputs => new[] {_pitchInputSignal, _rollInputSignal};
+
+        public override AnalogSignal[] AnalogOutputs => new[]
+            {_pitchSinOutputSignal, _pitchCosOutputSignal, _rollSinOutputSignal, _rollCosOutputSignal};
+
+        public override DigitalSignal[] DigitalInputs => null;
+
+        public override DigitalSignal[] DigitalOutputs => null;
+
+        public override string FriendlyName => "Simtek P/N 10-5859 - Indicator - Standby Attitude";
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Simtek105859HardwareSupportModule()
+        {
+            Dispose(false);
+        }
+
+        public static IHardwareSupportModule[] GetInstances()
+        {
+            Simtek105859HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Simtek105859HardwareSupportModule.config");
+                hsmConfig = Simtek105859HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Simtek105859HardwareSupportModule(hsmConfig) };
+        }
+
+        public override void Render(Graphics g, Rectangle destinationRectangle)
+        {
+            _renderer.InstrumentState.PitchDegrees = (float) _pitchInputSignal.State;
+            _renderer.InstrumentState.RollDegrees = (float) _rollInputSignal.State;
+            _renderer.Render(g, destinationRectangle);
+        }
+
+        private void AbandonInputEventHandlers()
+        {
+            _pitchInputSignalChangedEventHandler = null;
+            _rollInputSignalChangedEventHandler = null;
+        }
+
+        private void CreateInputEventHandlers()
+        {
+            _pitchInputSignalChangedEventHandler = pitch_InputSignalChanged;
+            _rollInputSignalChangedEventHandler = roll_InputSignalChanged;
+        }
+
+        private void CreateInputSignals()
+        {
+            _pitchInputSignal = CreatePitchInputSignal();
+            _rollInputSignal = CreateRollInputSignal();
+        }
+
+        private void CreateOutputSignals()
+        {
+            _pitchSinOutputSignal = CreatePitchSinOutputSignal();
+            _pitchCosOutputSignal = CreatePitchCosOutputSignal();
+            _rollSinOutputSignal = CreateRollSinOutputSignal();
+            _rollCosOutputSignal = CreateRollCosOutputSignal();
+        }
+
+        private AnalogSignal CreatePitchInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "Pitch (Degrees)",
+                Id = "105859_Pitch_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                IsAngle = true,
+                MinValue = -90,
+                MaxValue = 90
+            };
+        }
+
+        private AnalogSignal CreateRollInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "Roll (Degrees)",
+                Id = "105859_Roll_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                IsAngle = true,
+                MinValue = -180,
+                MaxValue = 180
+            };
+        }
+
+        private AnalogSignal CreatePitchSinOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Pitch (SIN)",
+                Id = "105859_Pitch_SIN_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0.00,
+                IsVoltage = true,
+                IsSine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreatePitchCosOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Pitch (COS)",
+                Id = "105859_Pitch_COS_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = +10.00,
+                IsVoltage = true,
+                IsCosine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreateRollSinOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Roll (SIN)",
+                Id = "105859_Roll_SIN_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0.00,
+                IsVoltage = true,
+                IsSine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreateRollCosOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Roll (COS)",
+                Id = "105859_Roll_COS_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = +10.00,
+                IsVoltage = true,
+                IsCosine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    UnregisterForInputEvents();
+                    AbandonInputEventHandlers();
+                    Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
+                }
+            }
+            _isDisposed = true;
+        }
+
+        private void pitch_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdatePitchOutputValues();
+        }
+
+        private void roll_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateRollOutputValues();
+        }
+
+        private void RegisterForInputEvents()
+        {
+            if (_pitchInputSignal != null)
+            {
+                _pitchInputSignal.SignalChanged += _pitchInputSignalChangedEventHandler;
+            }
+            if (_rollInputSignal != null)
+            {
+                _rollInputSignal.SignalChanged += _rollInputSignalChangedEventHandler;
+            }
+        }
+
+        private void UnregisterForInputEvents()
+        {
+            if (_pitchInputSignalChangedEventHandler != null && _pitchInputSignal != null)
+            {
+                try { _pitchInputSignal.SignalChanged -= _pitchInputSignalChangedEventHandler; }
+                catch (RemotingException) { }
+            }
+            if (_rollInputSignalChangedEventHandler != null && _rollInputSignal != null)
+            {
+                try { _rollInputSignal.SignalChanged -= _rollInputSignalChangedEventHandler; }
+                catch (RemotingException) { }
+            }
+        }
+
+        // Pitch piecewise_resolver. Reference angle table from PL20-5859
+        // Table 1 (sheet 5). Hardcoded path matches the editor's defaults
+        // exactly via linear interpolation between adjacent test points.
+        // Outside the [-90, +90] range the table clamps to the endpoint
+        // angle (±90° both reach the inverted "DOT" position at 194.82°).
+        private void UpdatePitchOutputValues()
+        {
+            if (_pitchInputSignal == null) return;
+            var pitchInputDegrees = _pitchInputSignal.State;
+
+            if (_pitchTransform != null
+                && _pitchSinChannel != null
+                && _pitchCosChannel != null
+                && _pitchSinOutputSignal != null
+                && _pitchCosOutputSignal != null)
+            {
+                var t = _pitchTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    pitchInputDegrees, t.Breakpoints, t.PeakVolts.Value);
+                _pitchSinOutputSignal.State = _pitchSinChannel.ApplyTrim(sinCos[0], _pitchSinOutputSignal.MinValue, _pitchSinOutputSignal.MaxValue);
+                _pitchCosOutputSignal.State = _pitchCosChannel.ApplyTrim(sinCos[1], _pitchCosOutputSignal.MinValue, _pitchCosOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback: same per-segment linear interpolation as
+            // 10-1084 (the angles match the spec to within rounding).
+            double refAngle;
+            if (pitchInputDegrees >= 0 && pitchInputDegrees < 10)
+                refAngle = (pitchInputDegrees / 10.0) * 21.18;
+            else if (pitchInputDegrees >= 10 && pitchInputDegrees < 20)
+                refAngle = (((pitchInputDegrees - 10) / 10.0) * (42.35 - 21.18)) + 21.18;
+            else if (pitchInputDegrees >= 20 && pitchInputDegrees < 30)
+                refAngle = (((pitchInputDegrees - 20) / 10.0) * (63.53 - 42.35)) + 42.35;
+            else if (pitchInputDegrees >= 30 && pitchInputDegrees < 60)
+                refAngle = (((pitchInputDegrees - 30) / 30.0) * (127.10 - 63.53)) + 63.53;
+            else if (pitchInputDegrees >= 60 && pitchInputDegrees <= 90)
+                refAngle = (((pitchInputDegrees - 60) / 30.0) * (194.82 - 127.10)) + 127.10;
+            else if (pitchInputDegrees < 0 && pitchInputDegrees >= -10)
+                refAngle = (((pitchInputDegrees + 10) / 10.0) * (360.00 - 338.82)) + 338.82;
+            else if (pitchInputDegrees < -10 && pitchInputDegrees >= -20)
+                refAngle = (((pitchInputDegrees + 20) / 10.0) * (338.82 - 317.65)) + 317.65;
+            else if (pitchInputDegrees < -20 && pitchInputDegrees >= -30)
+                refAngle = (((pitchInputDegrees + 30) / 10.0) * (317.65 - 296.47)) + 296.47;
+            else if (pitchInputDegrees < -30 && pitchInputDegrees >= -60)
+                refAngle = (((pitchInputDegrees + 60) / 30.0) * (296.47 - 232.94)) + 232.94;
+            else if (pitchInputDegrees < -60 && pitchInputDegrees >= -90)
+                refAngle = (((pitchInputDegrees + 90) / 30.0) * (232.94 - 194.82)) + 194.82;
+            else
+                refAngle = pitchInputDegrees > 90 ? 194.82 : 194.82;
+
+            var sin = 10.0 * Math.Sin(refAngle * Constants.RADIANS_PER_DEGREE);
+            var cos = 10.0 * Math.Cos(refAngle * Constants.RADIANS_PER_DEGREE);
+            _pitchSinOutputSignal.State = Clamp(sin);
+            _pitchCosOutputSignal.State = Clamp(cos);
+        }
+
+        // Roll piecewise_resolver. Reference angle table from PL20-5859
+        // Table 2 (sheet 6). Roll left → angle 270..360 (CCW from 12
+        // o'clock); roll right → 0..90 (CW). Encoded monotonically in
+        // the editor as 270..450 (right side wraps past 360).
+        private void UpdateRollOutputValues()
+        {
+            if (_rollInputSignal == null) return;
+            var rollInputDegrees = _rollInputSignal.State;
+
+            if (_rollTransform != null
+                && _rollSinChannel != null
+                && _rollCosChannel != null
+                && _rollSinOutputSignal != null
+                && _rollCosOutputSignal != null)
+            {
+                var t = _rollTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    rollInputDegrees, t.Breakpoints, t.PeakVolts.Value);
+                _rollSinOutputSignal.State = _rollSinChannel.ApplyTrim(sinCos[0], _rollSinOutputSignal.MinValue, _rollSinOutputSignal.MaxValue);
+                _rollCosOutputSignal.State = _rollCosChannel.ApplyTrim(sinCos[1], _rollCosOutputSignal.MinValue, _rollCosOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback: roll input in degrees == reference angle
+            // (linear 1:1 mapping). The Table 2 mapping (90L→270, 0→0,
+            // 90R→90) is identical to "reference angle = -roll degrees mod
+            // 360" for roll left being negative input — we treat the C#
+            // input convention as positive=right, negative=left, so
+            // reference angle = roll degrees works for both directions
+            // (90L = -90° input → -90° angle = 270°; 90R = +90° input
+            // → 90° angle).
+            var refAngle = rollInputDegrees;
+            var sin = 10.0 * Math.Sin(refAngle * Constants.RADIANS_PER_DEGREE);
+            var cos = 10.0 * Math.Cos(refAngle * Constants.RADIANS_PER_DEGREE);
+            _rollSinOutputSignal.State = Clamp(sin);
+            _rollCosOutputSignal.State = Clamp(cos);
+        }
+
+        private static double Clamp(double v)
+        {
+            if (v < -10) return -10;
+            if (v > 10) return 10;
+            return v;
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105859HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105859HardwareSupportModuleConfig.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    // Per-gauge calibration config for Simtek 10-5859 (F-16 Standby Attitude
+    // Indicator). Two channel pairs:
+    //
+    //   1. Pitch (piecewise_resolver):
+    //      105859_Pitch_SIN_To_Instrument (carries the breakpoint table)
+    //      105859_Pitch_COS_To_Instrument (role="cos", points back to SIN)
+    //   2. Roll (piecewise_resolver):
+    //      105859_Roll_SIN_To_Instrument (carries the breakpoint table)
+    //      105859_Roll_COS_To_Instrument (role="cos", points back to SIN)
+    //
+    // Drive type per the gauge spec sheet: dual DC servo. Calibration tables
+    // come from PL20-5859 Tables 1 & 2.
+    [Serializable]
+    [XmlRoot(nameof(Simtek105859HardwareSupportModule))]
+    public class Simtek105859HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Simtek105859HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Simtek105859HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105860HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105860HardwareSupportModule.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.Remoting;
+using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
+using Common.MacroProgramming;
+using LightningGauges.Renderers.F16;
+using log4net;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    //Simtek 10-5860 F-16 Fuel Flow Indicator (piecewise: 0..80,000 PPH → ±10 V)
+    //
+    // Per the spec sheet (PL20-5860, dwg 10-5860):
+    //   Drive type: SINGLE DC SERVO
+    //   Calibration: Table 1 — 9 test points, PPH×100 0..800 → -10..+10 V
+    //                  linear (2.5 V per 100 PPH×100, i.e. 1 V per 4000 PPH).
+    //   Display: 5-digit counter, two least-significant digits fixed at "00".
+    //
+    // Modeled on Simtek100295HardwareSupportModule (the existing F-16 fuel
+    // flow indicator). Renderer reuse: borrows IFuelFlow from 10-0295.
+    public class Simtek105860HardwareSupportModule : HardwareSupportModuleBase, IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Simtek105860HardwareSupportModule));
+        private readonly IFuelFlow _renderer = new FuelFlow();
+
+        // Editor-authored calibration. Default ships the 9 spec-sheet
+        // test points from PL20-5860 Table 1; users can edit any row to
+        // correct local hardware drift.
+        private Simtek105860HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _fuelFlowCalibration;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        private AnalogSignal _fuelFlowInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _fuelFlowInputSignalChangedEventHandler;
+        private AnalogSignal _fuelFlowOutputSignal;
+
+        private bool _isDisposed;
+
+        public Simtek105860HardwareSupportModule(Simtek105860HardwareSupportModuleConfig config)
+        {
+            _config = config;
+            _fuelFlowCalibration = ResolvePiecewiseChannel(config, "105860_Fuel_Flow_To_Instrument");
+            CreateInputSignals();
+            CreateOutputSignals();
+            CreateInputEventHandlers();
+            RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Simtek105860HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                _fuelFlowCalibration = ResolvePiecewiseChannel(reloaded, "105860_Fuel_Flow_To_Instrument");
+                // Re-evaluate the output with the cached input value so the
+                // user sees the new calibration immediately.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        public override AnalogSignal[] AnalogInputs => new[] {_fuelFlowInputSignal};
+
+        public override AnalogSignal[] AnalogOutputs => new[] {_fuelFlowOutputSignal};
+
+        public override DigitalSignal[] DigitalInputs => null;
+
+        public override DigitalSignal[] DigitalOutputs => null;
+
+        public override string FriendlyName => "Simtek P/N 10-5860 - Fuel Flow Indicator";
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Simtek105860HardwareSupportModule()
+        {
+            Dispose(false);
+        }
+
+        public static IHardwareSupportModule[] GetInstances()
+        {
+            Simtek105860HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Simtek105860HardwareSupportModule.config");
+                hsmConfig = Simtek105860HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Simtek105860HardwareSupportModule(hsmConfig) };
+        }
+
+        public override void Render(Graphics g, Rectangle destinationRectangle)
+        {
+            _renderer.InstrumentState.FuelFlowPoundsPerHour = (float) _fuelFlowInputSignal.State;
+            _renderer.Render(g, destinationRectangle);
+        }
+
+        private void AbandonInputEventHandlers()
+        {
+            _fuelFlowInputSignalChangedEventHandler = null;
+        }
+
+        private AnalogSignal CreateFuelFlowInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "Fuel Flow (pounds per hour)",
+                Id = "105860_Fuel_Flow_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                MinValue = 0,
+                MaxValue = 80000
+            };
+        }
+
+        private AnalogSignal CreateFuelFlowOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Fuel Flow",
+                Id = "105860_Fuel_Flow_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = -10.00,
+                IsVoltage = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private void CreateInputEventHandlers()
+        {
+            _fuelFlowInputSignalChangedEventHandler = fuelFlow_InputSignalChanged;
+        }
+
+        private void CreateInputSignals()
+        {
+            _fuelFlowInputSignal = CreateFuelFlowInputSignal();
+        }
+
+        private void CreateOutputSignals()
+        {
+            _fuelFlowOutputSignal = CreateFuelFlowOutputSignal();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    UnregisterForInputEvents();
+                    AbandonInputEventHandlers();
+                    Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
+                }
+            }
+            _isDisposed = true;
+        }
+
+        private void fuelFlow_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateOutputValues();
+        }
+
+        private void RegisterForInputEvents()
+        {
+            if (_fuelFlowInputSignal != null)
+            {
+                _fuelFlowInputSignal.SignalChanged += _fuelFlowInputSignalChangedEventHandler;
+            }
+        }
+
+        private void UnregisterForInputEvents()
+        {
+            if (_fuelFlowInputSignalChangedEventHandler == null || _fuelFlowInputSignal == null) return;
+            try { _fuelFlowInputSignal.SignalChanged -= _fuelFlowInputSignalChangedEventHandler; }
+            catch (RemotingException) { }
+        }
+
+        private void UpdateOutputValues()
+        {
+            if (_fuelFlowOutputSignal == null) return;
+            var fuelFlow = _fuelFlowInputSignal.State;
+
+            // Editor-authored override: when a .config file declared a
+            // piecewise table, evaluate via the generic helper + per-channel
+            // trim. Falls through to the linear formula below when no
+            // config is present.
+            if (_fuelFlowCalibration != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(fuelFlow, _fuelFlowCalibration.Transform.Breakpoints);
+                _fuelFlowOutputSignal.State = _fuelFlowCalibration.ApplyTrim(v, _fuelFlowOutputSignal.MinValue, _fuelFlowOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback: PL20-5860 Table 1 is exactly linear from
+            // 0 PPH → -10 V to 80,000 PPH → +10 V. (PPH×100 of 0..800 in
+            // 100 steps maps to 9 evenly-spaced 2.5 V increments.)
+            var clamped = fuelFlow < 0 ? 0 : (fuelFlow > 80000 ? 80000 : fuelFlow);
+            _fuelFlowOutputSignal.State = (clamped / 80000.0) * 20.0 - 10.0;
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105860HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105860HardwareSupportModuleConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    // Per-gauge calibration config for Simtek 10-5860 (F-16 Fuel Flow
+    // Indicator). Single piecewise channel:
+    //
+    //   105860_Fuel_Flow_To_Instrument (kind="piecewise")
+    //
+    // Default breakpoints come from PL20-5860 Table 1 — 9 spec-sheet
+    // test points at PPH×100 = 0, 100, 200, …, 800 mapped to -10..+10 V
+    // linearly. The dial reads 0..80,000 PPH with the two least
+    // significant digits fixed at 00.
+    [Serializable]
+    [XmlRoot(nameof(Simtek105860HardwareSupportModule))]
+    public class Simtek105860HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Simtek105860HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Simtek105860HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105862HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105862HardwareSupportModule.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.Remoting;
+using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
+using Common.MacroProgramming;
+using Common.Math;
+using LightningGauges.Renderers.F16;
+using log4net;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    //Simtek 10-5862 F-16 Nozzle Position Indicator (resolver pair: 0..100% → 0..225°)
+    //
+    // Per the spec sheet (PL20-5862, dwg 10-5862):
+    //   Drive type: SINGLE DC SYNCHRO
+    //   Calibration: Table 1 — 6 test points, 0..100% open → 0..225°
+    //                  linear (45° per 20% increment).
+    //   Signal: 10 VDC × sin/cos of reference angle.
+    //
+    // Modeled on Simtek101088HardwareSupportModule (the existing F-16
+    // nozzle position indicator). Renderer reuse: borrows
+    // INozzlePositionIndicator from 10-1088.
+    public class Simtek105862HardwareSupportModule : HardwareSupportModuleBase, IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Simtek105862HardwareSupportModule));
+        private readonly INozzlePositionIndicator _renderer = new NozzlePositionIndicator();
+
+        private Simtek105862HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        private bool _isDisposed;
+        private AnalogSignal _nozzlePositionCOSOutputSignal;
+        private AnalogSignal _nozzlePositionInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _nozzlePositionInputSignalChangedEventHandler;
+        private AnalogSignal _nozzlePositionSINOutputSignal;
+
+        public Simtek105862HardwareSupportModule(Simtek105862HardwareSupportModuleConfig config)
+        {
+            _config = config;
+            ResolvePiecewiseResolverPair(config,
+                "105862_Nozzle_Position_SIN_To_Instrument",
+                "105862_Nozzle_Position_COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+            CreateInputSignals();
+            CreateOutputSignals();
+            CreateInputEventHandlers();
+            RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Simtek105862HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolvePiecewiseResolverPair(reloaded,
+                    "105862_Nozzle_Position_SIN_To_Instrument",
+                    "105862_Nozzle_Position_COS_To_Instrument",
+                    out _resolverTransform, out _sinChannel, out _cosChannel);
+                // Re-evaluate the outputs with the cached input value so the
+                // user sees the new calibration immediately.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        public override AnalogSignal[] AnalogInputs => new[] {_nozzlePositionInputSignal};
+
+        public override AnalogSignal[] AnalogOutputs => new[]
+            {_nozzlePositionSINOutputSignal, _nozzlePositionCOSOutputSignal};
+
+        public override DigitalSignal[] DigitalInputs => null;
+
+        public override DigitalSignal[] DigitalOutputs => null;
+
+        public override string FriendlyName => "Simtek P/N 10-5862 - Nozzle Position Ind";
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Simtek105862HardwareSupportModule()
+        {
+            Dispose(false);
+        }
+
+        public static IHardwareSupportModule[] GetInstances()
+        {
+            Simtek105862HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Simtek105862HardwareSupportModule.config");
+                hsmConfig = Simtek105862HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Simtek105862HardwareSupportModule(hsmConfig) };
+        }
+
+        public override void Render(Graphics g, Rectangle destinationRectangle)
+        {
+            _renderer.InstrumentState.NozzlePositionPercent = (float) _nozzlePositionInputSignal.State;
+            _renderer.Render(g, destinationRectangle);
+        }
+
+        private void AbandonInputEventHandlers()
+        {
+            _nozzlePositionInputSignalChangedEventHandler = null;
+        }
+
+        private void CreateInputEventHandlers()
+        {
+            _nozzlePositionInputSignalChangedEventHandler = nozzlePosition_InputSignalChanged;
+        }
+
+        private void CreateInputSignals()
+        {
+            _nozzlePositionInputSignal = CreateNozzlePositionInputSignal();
+        }
+
+        private AnalogSignal CreateNozzlePositionInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "Nozzle Position (0-100%)",
+                Id = "105862_Nozzle_Position_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                IsPercentage = true,
+                MinValue = 0,
+                MaxValue = 100
+            };
+        }
+
+        private AnalogSignal CreateNozzlePositionSINOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Nozzle Position (SIN)",
+                Id = "105862_Nozzle_Position_SIN_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0.00,
+                IsVoltage = true,
+                IsSine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreateNozzlePositionCOSOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Nozzle Position (COS)",
+                Id = "105862_Nozzle_Position_COS_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 10.00,
+                IsVoltage = true,
+                IsCosine = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private void CreateOutputSignals()
+        {
+            _nozzlePositionSINOutputSignal = CreateNozzlePositionSINOutputSignal();
+            _nozzlePositionCOSOutputSignal = CreateNozzlePositionCOSOutputSignal();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    UnregisterForInputEvents();
+                    AbandonInputEventHandlers();
+                    Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
+                }
+            }
+            _isDisposed = true;
+        }
+
+        private void nozzlePosition_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateOutputValues();
+        }
+
+        private void RegisterForInputEvents()
+        {
+            if (_nozzlePositionInputSignal != null)
+            {
+                _nozzlePositionInputSignal.SignalChanged += _nozzlePositionInputSignalChangedEventHandler;
+            }
+        }
+
+        private void UnregisterForInputEvents()
+        {
+            if (_nozzlePositionInputSignalChangedEventHandler == null || _nozzlePositionInputSignal == null) return;
+            try { _nozzlePositionInputSignal.SignalChanged -= _nozzlePositionInputSignalChangedEventHandler; }
+            catch (RemotingException) { }
+        }
+
+        private void UpdateOutputValues()
+        {
+            if (_nozzlePositionInputSignal == null) return;
+            var nozzlePositionInput = _nozzlePositionInputSignal.State;
+
+            // Editor-authored override.
+            if (_resolverTransform != null
+                && _sinChannel != null
+                && _cosChannel != null
+                && _nozzlePositionSINOutputSignal != null
+                && _nozzlePositionCOSOutputSignal != null)
+            {
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    nozzlePositionInput, t.Breakpoints, t.PeakVolts.Value);
+                _nozzlePositionSINOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _nozzlePositionSINOutputSignal.MinValue, _nozzlePositionSINOutputSignal.MaxValue);
+                _nozzlePositionCOSOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _nozzlePositionCOSOutputSignal.MinValue, _nozzlePositionCOSOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback: 0..100% → 0..225° linear.
+            var clamped = nozzlePositionInput < 0 ? 0 : (nozzlePositionInput > 100 ? 100 : nozzlePositionInput);
+            var refAngle = clamped / 100.0 * 225.0;
+            var sin = 10.0 * Math.Sin(refAngle * Constants.RADIANS_PER_DEGREE);
+            var cos = 10.0 * Math.Cos(refAngle * Constants.RADIANS_PER_DEGREE);
+            if (_nozzlePositionSINOutputSignal != null) _nozzlePositionSINOutputSignal.State = Clamp(sin);
+            if (_nozzlePositionCOSOutputSignal != null) _nozzlePositionCOSOutputSignal.State = Clamp(cos);
+        }
+
+        private static double Clamp(double v)
+        {
+            if (v < -10) return -10;
+            if (v > 10) return 10;
+            return v;
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105862HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105862HardwareSupportModuleConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    // Per-gauge calibration config for Simtek 10-5862 (F-16 Nozzle Position
+    // Indicator). Single resolver pair:
+    //
+    //   105862_Nozzle_Position_SIN_To_Instrument (carries the breakpoint table)
+    //   105862_Nozzle_Position_COS_To_Instrument (role="cos", points back)
+    //
+    // Default breakpoints come from PL20-5862 Table 1 — 6 spec-sheet test
+    // points: 0..100% open mapped to 0..225° reference angle linearly
+    // (45° per 20% increment). Drive type: single DC synchro.
+    [Serializable]
+    [XmlRoot(nameof(Simtek105862HardwareSupportModule))]
+    public class Simtek105862HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Simtek105862HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Simtek105862HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105866HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105866HardwareSupportModule.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.Remoting;
+using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
+using Common.MacroProgramming;
+using LightningGauges.Renderers.F16;
+using log4net;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    //Simtek 10-5866 F-16 Fuel Quantity Indicator (multi-pointer, with remote electronics)
+    //
+    // Per the spec sheet (PL20-5866, dwg 10-5866):
+    //   Drive type: MULTIPLE DC SERVO
+    //   Connectors: 3 signal inputs (A/L, F/R, TOTAL)
+    //   Calibration:
+    //     Table 1 — SEL LBS×100, 0..42 (0..4200 LBS) → -10..+10 V linear
+    //               (used for both A/L and F/R pointers; cockpit switch
+    //                selects which signal drives SEL pointer).
+    //     Table 2 — TOTAL LBS, 0..20000 → -10..+10 V linear (5-digit
+    //                counter at the bottom of the dial).
+    //   Remote electronics: 50-4363-01 (separate enclosure, see PL20-5866 fig 2).
+    //
+    // Modeled on Simtek10108902HardwareSupportModule (the existing F-16
+    // fuel quantity indicator v2). Renderer reuse: borrows
+    // IFuelQuantityIndicator from 10-1089-02.
+    public class Simtek105866HardwareSupportModule : HardwareSupportModuleBase, IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Simtek105866HardwareSupportModule));
+        private readonly IFuelQuantityIndicator _renderer = new FuelQuantityIndicator();
+
+        private AnalogSignal _aftLeftFuelInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _aftLeftFuelInputSignalChangedEventHandler;
+        private AnalogSignal _aftLeftOutputSignal;
+        private AnalogSignal _counterOutputSignal;
+        private AnalogSignal _foreRightFuelInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _foreRightFuelInputSignalChangedEventHandler;
+        private AnalogSignal _foreRightOutputSignal;
+        private bool _isDisposed;
+        private AnalogSignal _totalFuelInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _totalFuelInputSignalChangedEventHandler;
+
+        private Simtek105866HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _counterChannel;
+        private GaugeChannelConfig _aftLeftChannel;
+        private GaugeChannelConfig _foreRightChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Simtek105866HardwareSupportModule(Simtek105866HardwareSupportModuleConfig config)
+        {
+            _config = config;
+            ResolveAllChannels(config);
+            CreateInputSignals();
+            CreateOutputSignals();
+            CreateInputEventHandlers();
+            RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _counterChannel  = ResolvePiecewiseChannel(config, "105866_Counter_To_Instrument");
+            _aftLeftChannel  = ResolvePiecewiseChannel(config, "105866_AL_To_Instrument");
+            _foreRightChannel = ResolvePiecewiseChannel(config, "105866_FR_To_Instrument");
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Simtek105866HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate the outputs with the cached input values so the
+                // user sees the new calibration immediately.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        public override AnalogSignal[] AnalogInputs => new[]
+            {_totalFuelInputSignal, _foreRightFuelInputSignal, _aftLeftFuelInputSignal};
+
+        public override AnalogSignal[] AnalogOutputs => new[]
+            {_foreRightOutputSignal, _aftLeftOutputSignal, _counterOutputSignal};
+
+        public override DigitalSignal[] DigitalInputs => null;
+
+        public override DigitalSignal[] DigitalOutputs => null;
+
+        public override string FriendlyName => "Simtek P/N 10-5866 - Indicator - Fuel Qty (Multi-Pointer)";
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Simtek105866HardwareSupportModule()
+        {
+            Dispose(false);
+        }
+
+        public static IHardwareSupportModule[] GetInstances()
+        {
+            Simtek105866HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Simtek105866HardwareSupportModule.config");
+                hsmConfig = Simtek105866HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Simtek105866HardwareSupportModule(hsmConfig) };
+        }
+
+        public override void Render(Graphics g, Rectangle destinationRectangle)
+        {
+            _renderer.InstrumentState.AftLeftFuelQuantityPounds = (float) _aftLeftFuelInputSignal.State;
+            _renderer.InstrumentState.ForeRightFuelQuantityPounds = (float) _foreRightFuelInputSignal.State;
+            _renderer.InstrumentState.TotalFuelQuantityPounds = (float) _totalFuelInputSignal.State;
+            _renderer.Render(g, destinationRectangle);
+        }
+
+        private void AbandonInputEventHandlers()
+        {
+            _totalFuelInputSignalChangedEventHandler = null;
+            _foreRightFuelInputSignalChangedEventHandler = null;
+            _aftLeftFuelInputSignalChangedEventHandler = null;
+        }
+
+        private AnalogSignal CreateAftLeftFuelInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "A/L Fuel",
+                Id = "105866_AftAndLeft_Fuel_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                MinValue = 0,
+                MaxValue = 4200
+            };
+        }
+
+        private AnalogSignal CreateAftLeftOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "A/L",
+                Id = "105866_AL_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = -10.00,
+                IsVoltage = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreateCounterOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "Counter",
+                Id = "105866_Counter_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = -10.00,
+                IsVoltage = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private AnalogSignal CreateForeRightFuelInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "F/R Fuel",
+                Id = "105866_ForeAndRight_Fuel_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                MinValue = 0,
+                MaxValue = 4200
+            };
+        }
+
+        private AnalogSignal CreateForeRightOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "F/R",
+                Id = "105866_FR_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = -10.00,
+                IsVoltage = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private void CreateInputEventHandlers()
+        {
+            _totalFuelInputSignalChangedEventHandler = fuel_InputSignalChanged;
+            _aftLeftFuelInputSignalChangedEventHandler = fuel_InputSignalChanged;
+            _foreRightFuelInputSignalChangedEventHandler = fuel_InputSignalChanged;
+        }
+
+        private void CreateInputSignals()
+        {
+            _totalFuelInputSignal = CreateTotalFuelInputSignal();
+            _aftLeftFuelInputSignal = CreateAftLeftFuelInputSignal();
+            _foreRightFuelInputSignal = CreateForeRightFuelInputSignal();
+        }
+
+        private void CreateOutputSignals()
+        {
+            _foreRightOutputSignal = CreateForeRightOutputSignal();
+            _aftLeftOutputSignal = CreateAftLeftOutputSignal();
+            _counterOutputSignal = CreateCounterOutputSignal();
+        }
+
+        private AnalogSignal CreateTotalFuelInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "Total Fuel (Pounds)",
+                Id = "105866_Total_Fuel_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                MinValue = 0,
+                MaxValue = 20000
+            };
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    UnregisterForInputEvents();
+                    AbandonInputEventHandlers();
+                    Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
+                }
+            }
+            _isDisposed = true;
+        }
+
+        private void fuel_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateOutputValues();
+        }
+
+        private void RegisterForInputEvents()
+        {
+            if (_totalFuelInputSignal != null)
+                _totalFuelInputSignal.SignalChanged += _totalFuelInputSignalChangedEventHandler;
+            if (_aftLeftFuelInputSignal != null)
+                _aftLeftFuelInputSignal.SignalChanged += _aftLeftFuelInputSignalChangedEventHandler;
+            if (_foreRightFuelInputSignal != null)
+                _foreRightFuelInputSignal.SignalChanged += _foreRightFuelInputSignalChangedEventHandler;
+        }
+
+        private void UnregisterForInputEvents()
+        {
+            if (_totalFuelInputSignalChangedEventHandler != null && _totalFuelInputSignal != null)
+            {
+                try { _totalFuelInputSignal.SignalChanged -= _totalFuelInputSignalChangedEventHandler; }
+                catch (RemotingException) { }
+            }
+            if (_aftLeftFuelInputSignalChangedEventHandler != null && _aftLeftFuelInputSignal != null)
+            {
+                try { _aftLeftFuelInputSignal.SignalChanged -= _aftLeftFuelInputSignalChangedEventHandler; }
+                catch (RemotingException) { }
+            }
+            if (_foreRightFuelInputSignalChangedEventHandler == null || _foreRightFuelInputSignal == null) return;
+            try { _foreRightFuelInputSignal.SignalChanged -= _foreRightFuelInputSignalChangedEventHandler; }
+            catch (RemotingException) { }
+        }
+
+        private void UpdateOutputValues()
+        {
+            // F/R pointer: 0..4200 lbs → -10..+10 V linear (Table 1).
+            if (_foreRightOutputSignal != null)
+            {
+                if (_foreRightChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _foreRightFuelInputSignal.State,
+                        _foreRightChannel.Transform.Breakpoints);
+                    _foreRightOutputSignal.State = _foreRightChannel.ApplyTrim(v, _foreRightOutputSignal.MinValue, _foreRightOutputSignal.MaxValue);
+                }
+                else
+                {
+                    _foreRightOutputSignal.State = _foreRightFuelInputSignal.State / 4200.0 * 20.0 - 10.0;
+                }
+            }
+
+            // A/L pointer: 0..4200 lbs → -10..+10 V linear (Table 1).
+            if (_aftLeftOutputSignal != null)
+            {
+                if (_aftLeftChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _aftLeftFuelInputSignal.State,
+                        _aftLeftChannel.Transform.Breakpoints);
+                    _aftLeftOutputSignal.State = _aftLeftChannel.ApplyTrim(v, _aftLeftOutputSignal.MinValue, _aftLeftOutputSignal.MaxValue);
+                }
+                else
+                {
+                    _aftLeftOutputSignal.State = _aftLeftFuelInputSignal.State / 4200.0 * 20.0 - 10.0;
+                }
+            }
+
+            // Counter: 0..20000 lbs → -10..+10 V linear (Table 2).
+            if (_counterOutputSignal != null)
+            {
+                if (_counterChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _totalFuelInputSignal.State,
+                        _counterChannel.Transform.Breakpoints);
+                    _counterOutputSignal.State = _counterChannel.ApplyTrim(v, _counterOutputSignal.MinValue, _counterOutputSignal.MaxValue);
+                }
+                else
+                {
+                    _counterOutputSignal.State = _totalFuelInputSignal.State / 20000.0 * 20.0 - 10.0;
+                }
+            }
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105866HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105866HardwareSupportModuleConfig.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    // Per-gauge calibration config for Simtek 10-5866 (F-16 Fuel Quantity
+    // Indicator, multi-pointer with remote electronics 50-4363-01).
+    //
+    // Three logical channels carried in the GaugeCalibrationConfig.Channels
+    // array (all kind="piecewise"):
+    //
+    //   105866_AL_To_Instrument        — A/L pointer (Table 1, 0..4200 LBS)
+    //   105866_FR_To_Instrument        — F/R pointer (Table 1, 0..4200 LBS)
+    //   105866_Counter_To_Instrument   — TOTAL counter (Table 2, 0..20000 LBS)
+    //
+    // The A/L and F/R pointers share the same calibration table per the
+    // spec sheet (PL20-5866 Table 1 — "SEL LBS X 100"); they're driven by
+    // the cockpit selector switch through separate signal pins (J, K) but
+    // both terminate at the same servo via the remote electronics box.
+    [Serializable]
+    [XmlRoot(nameof(Simtek105866HardwareSupportModule))]
+    public class Simtek105866HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Simtek105866HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Simtek105866HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105868HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105868HardwareSupportModule.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Runtime.Remoting;
+using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
+using Common.MacroProgramming;
+using LightningGauges.Renderers.F16;
+using log4net;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    //Simtek 10-5868 F-16 EPU FUEL QTY IND (piecewise: 0..100% → ±10 V)
+    //
+    // Per the spec sheet (PL20-5868, dwg 10-5868):
+    //   Drive type: SINGLE METER
+    //   Calibration: Table 1 — 11 test points, 0..100% remain → -10..+10 V
+    //                  linear (2 V per 10% increment).
+    //
+    // Modeled on Simtek101090HardwareSupportModule (the existing F-16 EPU
+    // fuel quantity indicator). Renderer reuse: borrows IEPUFuelGauge
+    // from 10-1090.
+    public class Simtek105868HardwareSupportModule : HardwareSupportModuleBase, IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Simtek105868HardwareSupportModule));
+        private readonly IEPUFuelGauge _renderer = new EPUFuelGauge();
+
+        private Simtek105868HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _epuCalibration;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        private AnalogSignal _epuFuelPercentageInputSignal;
+        private AnalogSignal.AnalogSignalChangedEventHandler _epuFuelPercentageInputSignalChangedEventHandler;
+        private AnalogSignal _epuFuelPercentageOutputSignal;
+
+        private bool _isDisposed;
+
+        public Simtek105868HardwareSupportModule(Simtek105868HardwareSupportModuleConfig config)
+        {
+            _config = config;
+            _epuCalibration = ResolvePiecewiseChannel(config, "105868_EPU_To_Instrument");
+            CreateInputSignals();
+            CreateOutputSignals();
+            CreateInputEventHandlers();
+            RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Simtek105868HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                _epuCalibration = ResolvePiecewiseChannel(reloaded, "105868_EPU_To_Instrument");
+                // Re-evaluate the output with the cached input value so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        public override AnalogSignal[] AnalogInputs => new[] {_epuFuelPercentageInputSignal};
+
+        public override AnalogSignal[] AnalogOutputs => new[] {_epuFuelPercentageOutputSignal};
+
+        public override DigitalSignal[] DigitalInputs => null;
+
+        public override DigitalSignal[] DigitalOutputs => null;
+
+        public override string FriendlyName => "Simtek P/N 10-5868 - EPU Fuel Quantity Ind";
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Simtek105868HardwareSupportModule()
+        {
+            Dispose(false);
+        }
+
+        public static IHardwareSupportModule[] GetInstances()
+        {
+            Simtek105868HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Simtek105868HardwareSupportModule.config");
+                hsmConfig = Simtek105868HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Simtek105868HardwareSupportModule(hsmConfig) };
+        }
+
+        public override void Render(Graphics g, Rectangle destinationRectangle)
+        {
+            _renderer.InstrumentState.FuelRemainingPercent = (float) _epuFuelPercentageInputSignal.State;
+            _renderer.Render(g, destinationRectangle);
+        }
+
+        private void AbandonInputEventHandlers()
+        {
+            _epuFuelPercentageInputSignalChangedEventHandler = null;
+        }
+
+        private AnalogSignal CreateEPUInputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Inputs",
+                CollectionName = "Analog Inputs",
+                FriendlyName = "EPU Fuel Quantity %",
+                Id = "105868_EPU_From_Sim",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = 0,
+                IsPercentage = true,
+                MinValue = 0,
+                MaxValue = 100
+            };
+        }
+
+        private AnalogSignal CreateEPUOutputSignal()
+        {
+            return new AnalogSignal
+            {
+                Category = "Outputs",
+                CollectionName = "Analog Outputs",
+                FriendlyName = "EPU Fuel Quantity %",
+                Id = "105868_EPU_To_Instrument",
+                Index = 0,
+                Source = this,
+                SourceFriendlyName = FriendlyName,
+                SourceAddress = null,
+                State = -10.00,
+                IsVoltage = true,
+                MinValue = -10,
+                MaxValue = 10
+            };
+        }
+
+        private void CreateInputEventHandlers()
+        {
+            _epuFuelPercentageInputSignalChangedEventHandler = epu_InputSignalChanged;
+        }
+
+        private void CreateInputSignals()
+        {
+            _epuFuelPercentageInputSignal = CreateEPUInputSignal();
+        }
+
+        private void CreateOutputSignals()
+        {
+            _epuFuelPercentageOutputSignal = CreateEPUOutputSignal();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    UnregisterForInputEvents();
+                    AbandonInputEventHandlers();
+                    Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
+                }
+            }
+            _isDisposed = true;
+        }
+
+        private void epu_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateOutputValues();
+        }
+
+        private void RegisterForInputEvents()
+        {
+            if (_epuFuelPercentageInputSignal != null)
+            {
+                _epuFuelPercentageInputSignal.SignalChanged += _epuFuelPercentageInputSignalChangedEventHandler;
+            }
+        }
+
+        private void UnregisterForInputEvents()
+        {
+            if (_epuFuelPercentageInputSignalChangedEventHandler != null && _epuFuelPercentageInputSignal != null)
+            {
+                try { _epuFuelPercentageInputSignal.SignalChanged -= _epuFuelPercentageInputSignalChangedEventHandler; }
+                catch (RemotingException) { }
+            }
+        }
+
+        private void UpdateOutputValues()
+        {
+            if (_epuFuelPercentageInputSignal == null) return;
+            var epuInput = _epuFuelPercentageInputSignal.State;
+            if (_epuFuelPercentageOutputSignal == null) return;
+
+            if (_epuCalibration != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(epuInput, _epuCalibration.Transform.Breakpoints);
+                _epuFuelPercentageOutputSignal.State = _epuCalibration.ApplyTrim(v, _epuFuelPercentageOutputSignal.MinValue, _epuFuelPercentageOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback: 0..100% → -10..+10 V linear.
+            var clamped = epuInput < 0 ? 0 : (epuInput > 100 ? 100 : epuInput);
+            var v2 = clamped / 100.0 * 20.0 - 10.0;
+            _epuFuelPercentageOutputSignal.State = v2;
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Simtek/Simtek105868HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/Simtek105868HardwareSupportModuleConfig.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Simtek
+{
+    // Per-gauge calibration config for Simtek 10-5868 (F-16 EPU Fuel
+    // Quantity Indicator). Single piecewise channel:
+    //
+    //   105868_EPU_To_Instrument (kind="piecewise")
+    //
+    // Default breakpoints come from PL20-5868 Table 1 — 11 spec-sheet
+    // test points 0..100% remain → -10..+10 V linear. Drive type:
+    // single meter.
+    [Serializable]
+    [XmlRoot(nameof(Simtek105868HardwareSupportModule))]
+    public class Simtek105868HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Simtek105868HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Simtek105868HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -182,6 +182,16 @@
     <Compile Include="HardwareSupport\Simtek\Simtek101084HardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Simtek\Simtek101090HardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Simtek\Simtek101091HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105859HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105859HardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105860HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105860HardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105862HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105862HardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105866HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105866HardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105868HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Simtek\Simtek105868HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\TeensyEWMU\DXOutput.cs" />
     <Compile Include="HardwareSupport\TeensyEWMU\TeensyEWMUCommunicationProtocolHeaders.cs" />
     <Compile Include="HardwareSupport\TeensyEWMU\TeensyEWMUHardwareSupportModule.cs" />


### PR DESCRIPTION
Adds C# HSMs and editor-authored calibration config schemas for five new Simtek F-16 instruments. All five are alternate part numbers of gauges already in the catalog (different vendor / different rev) but with their own spec-sheet calibration tables \xe2\x80\x94 none had HSMs before.

Each gauge gets:
- `SimtekXHardwareSupportModule.cs` \xe2\x80\x94 the gauge HSM (modeled on the closest existing Simtek HSM, listed below)
- `SimtekXHardwareSupportModuleConfig.cs` \xe2\x80\x94 thin subclass of `GaugeCalibrationConfig` that drives the editor's Calibration tab
- csproj `<Compile>` entries for both files

Per-gauge details:

| PN | Description | Modeled on | Calibration |
|----|-------------|------------|-------------|
| **10-5859** | F-16 Standby Attitude Indicator (dual DC servo) | 10-1084 | Pitch: 11-point `piecewise_resolver` from PL20-5859 Table 1; Roll: 9-point `piecewise_resolver` from Table 2 |
| **10-5860** | F-16 Fuel Flow Indicator (single DC servo) | 10-0295 | 9-point `piecewise`: 0..80,000 PPH \xe2\x86\x92 -10..+10 V linear from PL20-5860 Table 1 |
| **10-5862** | F-16 Nozzle Position Indicator (single DC synchro) | 10-1088 | 6-point `piecewise_resolver`: 0..100% open \xe2\x86\x92 0..225\xc2\xb0 from PL20-5862 Table 1 |
| **10-5866** | F-16 Fuel Quantity Indicator multi-pointer with 50-4363-01 remote electronics | 10-1089-02 | Three `piecewise` channels: A/L + F/R pointers (Table 1) + Total counter (Table 2) |
| **10-5868** | F-16 EPU Fuel Quantity Indicator (single meter) | 10-1090 | 11-point `piecewise`: 0..100% remain \xe2\x86\x92 -10..+10 V from PL20-5868 Table 1 |

All five HSMs use the standard editor-authored override pattern: config-driven piecewise (or `piecewise_resolver`) tables when a `SimtekXHardwareSupportModule.config` file is present in the profile directory; hardcoded spec-sheet fallback when not.

Each HSM uses `Common.HardwareSupport.Calibration.ConfigFileReloadWatcher` (#13) to watch its config file for hot-reload, and `GaugeCalibrationConfig` (#14) as the schema base. `ReloadConfig` calls the per-HSM `Update*OutputValues` at the end so the gauge reflects the new calibration immediately, without waiting for the next sim input change.

Renderer reuse: each gauge borrows the LightningGauges renderer from its precedent (cosmetic preview mismatch only \xe2\x80\x94 calibration and signal routing are independent).

11 files added, ~1960 lines.

---

**Stacked on #13 and #14**: this branch is based on top of `pr/gauge-calibration-config` (#14) which itself is on top of `pr/config-file-reload-watcher` (#13). For a clean review, merge in order: #13 \xe2\x86\x92 #14 \xe2\x86\x92 #15.