### PR TITLE
Wire 13 non-Simtek HSMs into the editor calibration schema

### DIFF
--- a/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
+++ b/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
@@ -1,0 +1,264 @@
+using System;
+using System.IO;
+using System.Threading;
+using log4net;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Resilient file watcher for editor-authored gauge config files.
+    //
+    // Replaces the per-HSM FileSystemWatcher boilerplate with three layers
+    // of defence against the well-known Windows file-watching failure
+    // modes:
+    //
+    //   1. InternalBufferSize bumped to 64 KB (max safe value before the
+    //      kernel starts dropping events). Avoids transient buffer
+    //      overflows during bursty multi-gauge saves.
+    //
+    //   2. Error event handler. When the watcher reports an internal
+    //      error (most commonly buffer overflow), dispose the watcher
+    //      and create a fresh one on a background timer beat.
+    //
+    //   3. Periodic resubscribe (every 30 s). Several Windows scenarios
+    //      silently orphan a FileSystemWatcher without firing an Error
+    //      event — antivirus / OneDrive / SMB filter drivers can drop
+    //      the IOCP completion notifications mid-flight, leaving the
+    //      watcher object alive but deaf. Periodic recreation guarantees
+    //      the watcher is fresh at most every 30 s. Belt-and-braces.
+    //
+    //   4. Mtime poll fallback (every 5 s). Even if all three watcher
+    //      layers fail, a polling timer reads the file's
+    //      LastWriteTime and triggers a reload when it changes. This
+    //      guarantees worst-case ~5 s latency between editor save and
+    //      gauge reload, even when the watcher is completely broken.
+    //
+    // Per-HSM usage:
+    //
+    //     // In the HSM's field section
+    //     private ConfigFileReloadWatcher _configWatcher;
+    //
+    //     // In StartConfigWatcher (or equivalent)
+    //     _configWatcher = new ConfigFileReloadWatcher(
+    //         _config.FilePath, ReloadConfig);
+    //
+    //     // In Dispose
+    //     if (_configWatcher != null) {
+    //         _configWatcher.Dispose();
+    //         _configWatcher = null;
+    //     }
+    //
+    //     // The HSM's existing reload method:
+    //     private void ReloadConfig() {
+    //         var reloaded = MyHardwareSupportModuleConfig.Load(_config.FilePath);
+    //         if (reloaded == null) return;
+    //         reloaded.FilePath = _config.FilePath;
+    //         _config = reloaded;
+    //         ResolveAllChannels(reloaded);
+    //     }
+    //
+    // The helper handles all dedup internally; the HSM's onChange callback
+    // can assume the file actually changed since the last call.
+    public sealed class ConfigFileReloadWatcher : IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(ConfigFileReloadWatcher));
+
+        // 30 s resubscribe and 5 s poll cadence picked as a compromise:
+        // fast enough that a "watcher silently died" scenario heals in
+        // about as long as it takes the user to retry a save, slow
+        // enough to cost ~negligible CPU when nothing is happening.
+        private const int RESUBSCRIBE_INTERVAL_MS = 30 * 1000;
+        private const int POLL_INTERVAL_MS = 5 * 1000;
+        private const int INTERNAL_BUFFER_SIZE = 64 * 1024;  // 64 KB max safe
+
+        private readonly string _filePath;
+        private readonly Action _onChange;
+        private readonly object _lock = new object();
+
+        private FileSystemWatcher _watcher;
+        private Timer _resubscribeTimer;
+        private Timer _pollTimer;
+        private DateTime _lastSeenWriteTime = DateTime.MinValue;
+        private bool _isDisposed;
+
+        public ConfigFileReloadWatcher(string filePath, Action onChange)
+        {
+            if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException("filePath");
+            if (onChange == null) throw new ArgumentNullException("onChange");
+            _filePath = filePath;
+            _onChange = onChange;
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    _lastSeenWriteTime = File.GetLastWriteTimeUtc(_filePath);
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Warn("Could not read initial mtime for " + _filePath + ": " + e.Message);
+            }
+            CreateWatcher();
+            // Resubscribe periodically to recover from silent orphaning.
+            _resubscribeTimer = new Timer(
+                _ => RecreateWatcher(reason: "periodic"),
+                state: null,
+                dueTime: RESUBSCRIBE_INTERVAL_MS,
+                period: RESUBSCRIBE_INTERVAL_MS);
+            // Poll mtime as a worst-case fallback.
+            _pollTimer = new Timer(
+                _ => PollOnce(),
+                state: null,
+                dueTime: POLL_INTERVAL_MS,
+                period: POLL_INTERVAL_MS);
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                if (_resubscribeTimer != null)
+                {
+                    try { _resubscribeTimer.Dispose(); } catch { }
+                    _resubscribeTimer = null;
+                }
+                if (_pollTimer != null)
+                {
+                    try { _pollTimer.Dispose(); } catch { }
+                    _pollTimer = null;
+                }
+                DisposeWatcher();
+            }
+        }
+
+        // Called from constructor and RecreateWatcher. Caller must hold
+        // the lock when entering from RecreateWatcher; constructor is
+        // single-threaded so it doesn't need to.
+        private void CreateWatcher()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                var name = Path.GetFileName(_filePath);
+                if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name)) return;
+                if (!Directory.Exists(dir)) return;
+                var w = new FileSystemWatcher(dir, name)
+                {
+                    InternalBufferSize = INTERNAL_BUFFER_SIZE,
+                    NotifyFilter = NotifyFilters.LastWrite
+                                 | NotifyFilters.Size
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.CreationTime,
+                };
+                // Watch all the events that can signal a save: Changed for
+                // in-place truncate-write (Node fs.writeFileSync), Created
+                // for atomic-replace patterns (rename-into-place), and
+                // Renamed for editors that use a temp file then rename.
+                w.Changed += OnFsEvent;
+                w.Created += OnFsEvent;
+                w.Renamed += OnFsRenamed;
+                w.Error += OnFsError;
+                w.EnableRaisingEvents = true;
+                _watcher = w;
+            }
+            catch (Exception e)
+            {
+                _log.Error("Could not create FileSystemWatcher for " + _filePath + ": " + e.Message, e);
+            }
+        }
+
+        private void DisposeWatcher()
+        {
+            var w = _watcher;
+            _watcher = null;
+            if (w == null) return;
+            try { w.EnableRaisingEvents = false; } catch { }
+            try { w.Changed -= OnFsEvent; } catch { }
+            try { w.Created -= OnFsEvent; } catch { }
+            try { w.Renamed -= OnFsRenamed; } catch { }
+            try { w.Error -= OnFsError; } catch { }
+            try { w.Dispose(); } catch { }
+        }
+
+        private void RecreateWatcher(string reason)
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                DisposeWatcher();
+                CreateWatcher();
+            }
+            // After recreating, also poll once in case the file changed
+            // during the brief window where we had no watcher armed.
+            PollOnce();
+        }
+
+        private void OnFsEvent(object sender, FileSystemEventArgs e)
+        {
+            MaybeFireReload();
+        }
+
+        private void OnFsRenamed(object sender, RenamedEventArgs e)
+        {
+            // Atomic-replace patterns rename the new file INTO the watched
+            // name, so the rename event signals a fresh file is in place.
+            MaybeFireReload();
+        }
+
+        private void OnFsError(object sender, ErrorEventArgs e)
+        {
+            // Most common cause: internal buffer overflow. Dispose and
+            // recreate the watcher; the poll timer will catch any
+            // mtime change that happened between events.
+            var ex = e.GetException();
+            _log.Warn("FileSystemWatcher error for " + _filePath +
+                ": " + (ex != null ? ex.Message : "unknown") +
+                " — recreating watcher");
+            RecreateWatcher(reason: "error");
+        }
+
+        private void PollOnce()
+        {
+            if (_isDisposed) return;
+            MaybeFireReload();
+        }
+
+        // Single source of truth for "should we tell the HSM to reload?"
+        // Compares the file's current LastWriteTimeUtc against the last
+        // value we successfully reloaded for. Returns early when nothing
+        // has changed. Synchronised so multiple watcher events firing
+        // close together (or a watcher event arriving the same instant
+        // the poll timer ticks) collapse into a single reload.
+        private void MaybeFireReload()
+        {
+            DateTime now;
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                try
+                {
+                    if (!File.Exists(_filePath)) return;
+                    now = File.GetLastWriteTimeUtc(_filePath);
+                }
+                catch
+                {
+                    return;
+                }
+                if (now == _lastSeenWriteTime) return;
+                _lastSeenWriteTime = now;
+            }
+            // Invoke the HSM's reload callback OUTSIDE the lock so a slow
+            // reload (XML parse + channel re-resolve) doesn't block other
+            // threads that want to fire events while we're working.
+            try
+            {
+                _onChange();
+            }
+            catch (Exception e)
+            {
+                _log.Error("Reload callback failed for " + _filePath + ": " + e.Message, e);
+            }
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -1,0 +1,538 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Shared base for per-gauge calibration configs authored by the SimLinkup
+    // Profile Editor. Each gauge HSM that opts in derives a thin subclass with
+    // [XmlRoot(nameof(<TheModule>))] so the on-disk root element name matches
+    // the gauge HSM class name (matches the existing Simtek100285 / Simtek100294
+    // precedent — and what the editor writes).
+    //
+    // Schema (matches the editor's gauge-config-io.js round-trip):
+    //   <YourModuleName>
+    //     <Channels>
+    //       <Channel id="<HSM-port-id>">
+    //         <Transform kind="piecewise|linear|resolver|multi_resolver|cross_coupled">
+    //           <Breakpoints>             <!-- piecewise only -->
+    //             <Point input="..." volts="..."/>
+    //             ...
+    //           </Breakpoints>
+    //         </Transform>
+    //         <ZeroTrimVolts>0</ZeroTrimVolts>
+    //         <GainTrim>1</GainTrim>
+    //         <CoupledTo>...</CoupledTo>  <!-- cross_coupled only, optional -->
+    //       </Channel>
+    //     </Channels>
+    //   </YourModuleName>
+    //
+    // Today only the 'piecewise' kind is honoured by SimLinkup's gauge HSMs;
+    // the others round-trip safely so files survive future schema growth.
+    [Serializable]
+    public class GaugeCalibrationConfig
+    {
+        [XmlArray("Channels")]
+        [XmlArrayItem("Channel")]
+        public GaugeChannelConfig[] Channels { get; set; }
+
+        // Set by GetInstances after Load() so the gauge HSM's FileSystemWatcher
+        // knows which file to watch for hot-reload. [XmlIgnore] keeps it out of
+        // the round-trip (matches the ArduinoSeatHardwareSupportModuleConfig
+        // precedent).
+        [XmlIgnore]
+        public string FilePath { get; set; }
+
+        // Find a channel by its HSM port Id. Returns null when not present —
+        // gauge HSMs treat that as "no override; use hardcoded behaviour."
+        public GaugeChannelConfig FindChannel(string id)
+        {
+            if (Channels == null || string.IsNullOrEmpty(id)) return null;
+            return Channels.FirstOrDefault(c => c != null && c.Id == id);
+        }
+
+        // Generic loader. The caller passes T = derived per-gauge subclass and
+        // gets a strongly-typed result back. Safe to call when the file is
+        // absent — returns null in that case (callers fall back to hardcoded
+        // behaviour, matching the 10-0285 / 10-0294 precedent).
+        //
+        // Hot-reload-safe: this loader is what every editor-authored gauge
+        // config flows through, both at SimLinkup startup AND on every
+        // FileSystemWatcher Changed event. The watcher path races the
+        // editor's writer — the SimLinkup Profile Editor saves via Node's
+        // fs.writeFileSync, which on Windows triggers Changed events both
+        // when the file is truncated (size 0, XmlSerializer fails because
+        // the document is empty) AND when content is fully written. The
+        // first event arrives mid-write; without retries the watcher's
+        // change handler bails on it and the dedup mtime check skips
+        // subsequent events because LastWriteTime didn't change between
+        // truncate and write-complete on the same save. We close that
+        // race two ways:
+        //   1. Open the file with FileShare.ReadWrite so a writer holding
+        //      the file with default sharing doesn't lock us out
+        //      ("being used by another process" IOException).
+        //   2. Retry on transient failures (IOException + the
+        //      InvalidOperationException XmlSerializer throws on partial
+        //      documents) — 6 attempts × 50ms = ~300ms total, which
+        //      comfortably covers Node's writeFileSync window.
+        //
+        // Startup reads (no concurrent writer) hit the first attempt and
+        // return immediately, so this is free for the common case.
+        public static T Load<T>(string filePath) where T : GaugeCalibrationConfig
+        {
+            return Load<T>(filePath, attempts: 6, delayMs: 50);
+        }
+
+        public static T Load<T>(string filePath, int attempts, int delayMs) where T : GaugeCalibrationConfig
+        {
+            if (filePath == null) throw new ArgumentNullException("filePath");
+            if (!System.IO.File.Exists(filePath)) return default(T);
+            if (attempts < 1) attempts = 1;
+            Exception last = null;
+            var serializer = new XmlSerializer(typeof(T));
+            for (var i = 0; i < attempts; i++)
+            {
+                try
+                {
+                    using (var fs = new System.IO.FileStream(
+                        filePath,
+                        System.IO.FileMode.Open,
+                        System.IO.FileAccess.Read,
+                        System.IO.FileShare.ReadWrite))
+                    {
+                        return (T)serializer.Deserialize(fs);
+                    }
+                }
+                catch (System.IO.IOException e)
+                {
+                    last = e;  // editor's writer still holds the file — retry
+                }
+                catch (System.InvalidOperationException e)
+                {
+                    last = e;  // XmlSerializer hit a partial / empty file — retry
+                }
+                if (i + 1 < attempts && delayMs > 0)
+                {
+                    System.Threading.Thread.Sleep(delayMs);
+                }
+            }
+            // All retries exhausted; surface the last error so the caller's
+            // catch (every change-handler we've written) logs it.
+            if (last != null) throw last;
+            return default(T);
+        }
+
+        // Mirror of Save in the existing Simtek100285HardwareSupportModuleConfig
+        // precedent. Not used by SimLinkup itself today (the editor authors the
+        // file); included for symmetry and potential future round-trip tooling.
+        public void Save(string filePath)
+        {
+            Common.Serialization.Util.SerializeToXmlFile(this, filePath);
+        }
+    }
+
+    // Per-channel record. Distinguished by `Id` (matches the gauge HSM port
+    // signal Id, e.g. "100207_RPM_To_Instrument").
+    [Serializable]
+    public class GaugeChannelConfig
+    {
+        // The HSM output port Id this channel calibrates. Required.
+        [XmlAttribute("id")]
+        public string Id { get; set; }
+
+        // Transform record describing how input → volts is computed.
+        // Optional: when absent (or kind is unknown), gauge HSMs fall back to
+        // their hardcoded behaviour and still apply ZeroTrim/Gain on top.
+        [XmlElement("Transform")]
+        public GaugeTransformConfig Transform { get; set; }
+
+        // Per-channel zero-volt offset added to the computed transform output
+        // before the ±10 V clamp. 0 by default. Useful for trimming the gauge's
+        // physical needle zero point without changing the breakpoint table.
+        // Implemented as a nullable so we can distinguish "explicitly 0 in
+        // file" from "absent in file"; both behave the same way at runtime
+        // (additive offset of 0 is a no-op), but this lets future tooling
+        // tell the difference.
+        [XmlElement("ZeroTrimVolts")]
+        public double? ZeroTrimVolts { get; set; }
+
+        // Per-channel gain multiplier applied to the transform output before
+        // the ZeroTrim. 1.0 by default (unity). Useful for trimming full-scale
+        // span without re-tabulating breakpoints. Same nullable semantics as
+        // ZeroTrimVolts.
+        [XmlElement("GainTrim")]
+        public double? GainTrim { get; set; }
+
+        // Names another channel this one is computed from (cross_coupled).
+        // Round-trip-only today — SimLinkup's gauge HSMs don't yet act on it.
+        [XmlElement("CoupledTo")]
+        public string CoupledTo { get; set; }
+
+        // For digital_invert channels: whether the digital output is the
+        // logical inverse of the input. Defaults to false when absent. The
+        // 10-1084 ADI OFF flag uses this — its input is "OFF Flag Visible
+        // (1=visible)" and output is "OFF Flag Hidden (1=hidden)".
+        [XmlElement("Invert")]
+        public bool? Invert { get; set; }
+
+        // Caged-rest behaviour for standby ADI resolver pairs (pitch / roll
+        // SIN side carries these on each pair). When the gauge's OFF flag
+        // input is TRUE, the gauge's gimbal is mechanically caged — the
+        // gyro is at rest at whatever orientation it was in when last spun
+        // down, which is effectively random per power-cycle. The HSM picks
+        // a random angle in [Min, Max] degrees ONCE at construction time
+        // and drives sin/cos × PeakVolts to that angle for as long as the
+        // OFF flag stays TRUE. When the OFF flag goes FALSE (gauge spun
+        // up + uncaged), the HSM reverts to the configured piecewise
+        // transform and follows the input normally.
+        //
+        // Opt-in via CagedRestEnabled. Defaults to disabled (false / null)
+        // so existing profiles keep their pre-feature behaviour: when the
+        // OFF flag is visible the HSM continues to follow pitch/roll
+        // input regardless. Users who want the random rest behaviour
+        // enable it per gauge in the editor's Calibration tab.
+        //
+        // Only honoured by HSMs that opt in at the C# level (today:
+        // 10-0335-01 and 10-1084 standby ADIs, on their pitch and roll
+        // SIN channels). Editor defaults: pitch ±20°, roll ±40°. Set
+        // both Min and Max to the same value for a fixed (non-random)
+        // rest angle.
+        [XmlElement("CagedRestEnabled")]
+        public bool? CagedRestEnabled { get; set; }
+
+        [XmlElement("CagedRestRangeMinDegrees")]
+        public double? CagedRestRangeMinDegrees { get; set; }
+
+        [XmlElement("CagedRestRangeMaxDegrees")]
+        public double? CagedRestRangeMaxDegrees { get; set; }
+
+        // Apply ZeroTrim + GainTrim to a computed voltage, then clamp to
+        // [outputMin, outputMax] — the gauge's real hardware safe envelope
+        // (e.g. Westin EPU is 0.1..2.0 V, not the universal ±10 V). Callers
+        // pass the matching output signal's MinValue/MaxValue. The output
+        // signal is the canonical source of truth for what voltage is safe
+        // to send to the physical gauge mechanism, so trim values that
+        // would push the output past those bounds get clipped at the
+        // boundary instead of damaging the hardware.
+        //
+        // Order: gain first, then offset, then per-gauge clamp (matches
+        // what users intuitively expect when they say "make full-scale 5%
+        // wider then nudge zero up by 0.1 V").
+        //
+        // If outputMin >= outputMax (degenerate / unset bounds), returns 0
+        // so the gauge is visibly dead instead of quietly damaged. An HSM
+        // that forgets to declare MinValue/MaxValue on its output signal
+        // gets noticed on day one of testing rather than later.
+        public double ApplyTrim(double volts, double outputMin, double outputMax)
+        {
+            if (!(outputMin < outputMax)) return 0;
+            var gain   = GainTrim.HasValue      ? GainTrim.Value      : 1.0;
+            var offset = ZeroTrimVolts.HasValue ? ZeroTrimVolts.Value : 0.0;
+            var v = volts * gain + offset;
+            if (v < outputMin) return outputMin;
+            if (v > outputMax) return outputMax;
+            return v;
+        }
+    }
+
+    [Serializable]
+    public class GaugeTransformConfig
+    {
+        // 'piecewise' | 'linear' | 'resolver' | 'multi_resolver' | 'cross_coupled'.
+        // 'piecewise', 'linear', and 'resolver' are honoured by gauge HSMs
+        // today; the others round-trip for forward compatibility.
+        [XmlAttribute("kind")]
+        public string Kind { get; set; }
+
+        // Resolver pairs: each gauge has TWO output channels (sin + cos) but
+        // they share one transform. To avoid duplicating the transform on
+        // disk, the SIN channel carries the full transform body (InputMin,
+        // InputMax, AngleMin/MaxDegrees, PeakVolts, BelowMinBehavior) and
+        // the COS channel carries an empty body with role="cos" plus a
+        // PartnerChannel attribute pointing to the SIN channel id. The HSM
+        // reads both channels but pulls transform parameters from whichever
+        // carries them (always the SIN side as the editor writes it).
+        //
+        // role: "sin" or "cos" — present only for kind="resolver".
+        [XmlAttribute("role")]
+        public string Role { get; set; }
+
+        // Channel id of the partner (sin↔cos) — only set when Role is "cos".
+        [XmlAttribute("partnerChannel")]
+        public string PartnerChannel { get; set; }
+
+        // Piecewise transform: ordered breakpoint table. Linear interpolation
+        // between adjacent points; below the first / above the last clamps.
+        [XmlArray("Breakpoints")]
+        [XmlArrayItem("Point")]
+        public GaugeBreakpoint[] Breakpoints { get; set; }
+
+        // Linear and resolver transforms: maps `InputMin → angleMin / -10 V`
+        // and `InputMax → angleMax / +10 V`, with hard clamps outside.
+        // Nullable so the round-trip distinguishes "absent in file" from
+        // "explicitly set to 0".
+        [XmlElement("InputMin")]
+        public double? InputMin { get; set; }
+
+        [XmlElement("InputMax")]
+        public double? InputMax { get; set; }
+
+        // Resolver-specific: angular sweep mapped to [InputMin, InputMax].
+        // Default sweep is 0..360° if absent.
+        [XmlElement("AngleMinDegrees")]
+        public double? AngleMinDegrees { get; set; }
+
+        [XmlElement("AngleMaxDegrees")]
+        public double? AngleMaxDegrees { get; set; }
+
+        // Resolver peak voltage: sin/cos × PeakVolts is the output. Defaults
+        // to 10 V when absent — matches the Simtek 10-1088 convention.
+        [XmlElement("PeakVolts")]
+        public double? PeakVolts { get; set; }
+
+        // Resolver: what to do when input falls below InputMin. "zero" sets
+        // both outputs to 0 V (rest position; what 10-1088 nozzle does).
+        // "clamp" projects at angleMin (continuous behaviour expected by e.g.
+        // compass-style gauges). Default "clamp" if absent.
+        [XmlElement("BelowMinBehavior")]
+        public string BelowMinBehavior { get; set; }
+
+        // Multi-turn resolver: number of input units per full sin/cos
+        // revolution. Used by altimeter-style gauges where the synchro
+        // wraps many times across the input range (10-1081 altimeter
+        // fine = 1000 ft/rev; 10-0285 altimeter fine = 4000 ft/rev,
+        // coarse = 100000 ft/rev). The runtime computes
+        //   angle = (input / unitsPerRevolution) × 360°
+        // then sin/cos × peakVolts. No InputMin/Max needed — the sweep
+        // is unbounded; sin/cos handle negative angles cleanly.
+        [XmlElement("UnitsPerRevolution")]
+        public double? UnitsPerRevolution { get; set; }
+    }
+
+    [Serializable]
+    public class GaugeBreakpoint
+    {
+        [XmlAttribute("input")]
+        public double Input { get; set; }
+
+        // For piecewise transforms whose output is in volts (32 of the 33
+        // calibratable gauges in the editor). Default is 0 V; the C# default
+        // of `double` is also 0, so a gauge config that uses `output=` for
+        // raw DAC counts won't accidentally pick up the wrong value here.
+        [XmlAttribute("volts")]
+        public double Volts { get; set; }
+
+        // For piecewise transforms whose output is in raw DAC counts rather
+        // than volts (Henkie F-16 fuel flow drives its 12-bit DAC directly
+        // over USB/PHCC, bypassing AnalogDevices). Editor writes
+        // <Point input="500" output="18"/> for these gauges. HSMs that drive
+        // a DAC directly read this; HSMs that drive AD channels read Volts.
+        [XmlAttribute("output")]
+        public double Output { get; set; }
+
+        // For piecewise_resolver transforms: reference angle (degrees) at
+        // this input. Used by ADI-style gauges where the synchro angle is a
+        // non-linear function of the sim input (e.g. ADI pitch — input
+        // pitch°, output reference angle that drives a sin/cos pair). The
+        // angle should be encoded MONOTONICALLY in the breakpoint table —
+        // values may exceed 360° to keep linear interpolation working
+        // across the 360°→0° wrap; the runtime applies % 360 before
+        // computing sin/cos.
+        [XmlAttribute("angle")]
+        public double Angle { get; set; }
+    }
+
+    // Pure helpers. Live on the config namespace so per-gauge HSMs only need
+    // one `using Common.HardwareSupport.Calibration;` to evaluate a config.
+    public static class GaugeTransform
+    {
+        // Linearly interpolate `input` across an ordered list of breakpoints.
+        // Below the first breakpoint clamps to the first volts; above the last
+        // clamps to the last volts (matches the C# if/else fallback shape used
+        // by every Simtek HSM today). Returns the clamped voltage in ±10 V
+        // (final clamp lives in ApplyTrim, but pre-clamping here protects
+        // against breakpoints the editor may have flagged amber but saved).
+        //
+        // O(n) scan — the largest breakpoint table is 43 entries (10-0194
+        // airspeed); per-tick gauge update is well below any real cost.
+        public static double EvaluatePiecewise(double input, GaugeBreakpoint[] breakpoints)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                // Defensive: malformed config falls back to 0 V. Caller should
+                // detect this via a separate "config valid?" check before
+                // routing to this helper, but if they don't, 0 V is the
+                // safest neutral output.
+                return 0;
+            }
+            if (input <= breakpoints[0].Input) return Clamp(breakpoints[0].Volts);
+            var last = breakpoints[breakpoints.Length - 1];
+            if (input >= last.Input) return Clamp(last.Volts);
+            for (var i = 1; i < breakpoints.Length; i++)
+            {
+                var hi = breakpoints[i];
+                if (input < hi.Input)
+                {
+                    var lo = breakpoints[i - 1];
+                    var span = hi.Input - lo.Input;
+                    if (span <= 0) return Clamp(lo.Volts);  // degenerate; pick the lower
+                    var t = (input - lo.Input) / span;
+                    return Clamp(lo.Volts + t * (hi.Volts - lo.Volts));
+                }
+            }
+            return Clamp(last.Volts);
+        }
+
+        // Linear range: maps inputMin → -10 V, inputMax → +10 V, with hard
+        // clamps outside the range. Defensive against degenerate ranges
+        // (inputMin >= inputMax — returns 0 V neutral). Used by linear-pattern
+        // gauges (EPU fuel, fuel quantity, cabin altimeter, etc.).
+        public static double EvaluateLinear(double input, double inputMin, double inputMax)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return 0;
+            if (input <= inputMin) return -10;
+            if (input >= inputMax) return  10;
+            var t = (input - inputMin) / span;
+            return Clamp(-10 + t * 20);
+        }
+
+        // Resolver pair: maps `input` linearly to an angle in
+        // [angleMinDegrees, angleMaxDegrees], then projects to (sin, cos) ×
+        // peakVolts. `belowMinBehavior` controls the underflow case:
+        //   "zero"  — both outputs at 0 V (rest position; nozzle uses this)
+        //   "clamp" — project at angleMin (continuous; default)
+        // Above InputMax always clamps to angleMax (matches the C# nozzle
+        // shape and is the only behaviour that makes sense for a bounded
+        // mechanical gauge — full-scale stop).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each (sin and cos windings calibrate separately).
+        public static double[] EvaluateResolver(
+            double input,
+            double inputMin, double inputMax,
+            double angleMinDegrees, double angleMaxDegrees,
+            double peakVolts,
+            string belowMinBehavior)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return new double[] { 0, 0 };
+            double angleDeg;
+            if (input < inputMin)
+            {
+                if (string.Equals(belowMinBehavior, "zero", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new double[] { 0, 0 };
+                }
+                angleDeg = angleMinDegrees;
+            }
+            else if (input > inputMax)
+            {
+                angleDeg = angleMaxDegrees;
+            }
+            else
+            {
+                var t = (input - inputMin) / span;
+                angleDeg = angleMinDegrees + t * (angleMaxDegrees - angleMinDegrees);
+            }
+            // Fully qualify System.Math — there's a Common.Math namespace in
+            // sibling projects that shadows the unqualified `Math` here even
+            // with `using System;` in scope (because Common.HardwareSupport.
+            // Calibration is in the same parent namespace tree).
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Multi-turn resolver: input → angle = (input / unitsPerRevolution)
+        // × 360°, then sin/cos × peakVolts. The synchro wraps cleanly across
+        // many revolutions (negative angles included) — sin/cos handle it
+        // mathematically without any modulo logic. Used by altimeter-style
+        // gauges (10-1081 fine = 1000 ft/rev; 10-0285 fine = 4000 ft/rev).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each.
+        public static double[] EvaluateMultiTurnResolver(
+            double input,
+            double unitsPerRevolution,
+            double peakVolts)
+        {
+            if (unitsPerRevolution == 0) return new double[] { 0, 0 };
+            var revolutions = input / unitsPerRevolution;
+            var angleDeg = revolutions * 360.0;
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Piecewise-then-resolver: linearly interpolate `input` across the
+        // breakpoint table (where each Point's `Angle` is the reference
+        // angle in degrees), then project to (sin, cos) × peakVolts. Used
+        // by ADI-style gauges where the synchro angle is a non-linear
+        // function of the sim input (10-1084 pitch is the founding case).
+        //
+        // The angle table should be MONOTONICALLY increasing — values may
+        // exceed 360° to keep linear interpolation working across the
+        // 360°→0° wrap; this helper applies % 360 before sin/cos so the
+        // wrap is invisible to the synchro hardware.
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each. Below the first breakpoint clamps to the
+        // first angle; above the last clamps to the last (matches the
+        // EvaluatePiecewise voltage-clamp shape).
+        public static double[] EvaluatePiecewiseResolver(
+            double input,
+            GaugeBreakpoint[] breakpoints,
+            double peakVolts)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                return new double[] { 0, 0 };
+            }
+            double angleDeg;
+            if (input <= breakpoints[0].Input)
+            {
+                angleDeg = breakpoints[0].Angle;
+            }
+            else
+            {
+                var last = breakpoints[breakpoints.Length - 1];
+                if (input >= last.Input)
+                {
+                    angleDeg = last.Angle;
+                }
+                else
+                {
+                    angleDeg = last.Angle;  // overwritten in the loop unless degenerate
+                    for (var i = 1; i < breakpoints.Length; i++)
+                    {
+                        var hi = breakpoints[i];
+                        if (input < hi.Input)
+                        {
+                            var lo = breakpoints[i - 1];
+                            var span = hi.Input - lo.Input;
+                            if (span <= 0) { angleDeg = lo.Angle; break; }
+                            var t = (input - lo.Input) / span;
+                            angleDeg = lo.Angle + t * (hi.Angle - lo.Angle);
+                            break;
+                        }
+                    }
+                }
+            }
+            var rad = (angleDeg % 360.0) * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        private static double Clamp(double v)
+        {
+            if (v < -10) return -10;
+            if (v >  10) return  10;
+            return v;
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
+    <Compile Include="Calibration\GaugeCalibrationConfig.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -39,6 +39,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9000262001HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9000262001HardwareSupportModule.cs
@@ -1,17 +1,20 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
-using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.AMI
 {
     //AMI 90002620-01 F-16 Cabin Pressure Altimeter
     public class AMI9000262001HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(AMI9000262001HardwareSupportModule));
         private readonly ICabinPressureAltitudeIndicator _renderer = new CabinPressureAltitudeIndicator();
 
         private AnalogSignal _cabinPressureAltitudeInputSignal;
@@ -20,12 +23,75 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private bool _isDisposed;
 
-        private AMI9000262001HardwareSupportModule()
+        private AMI9000262001HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _cabinAltChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public AMI9000262001HardwareSupportModule(AMI9000262001HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _cabinAltChannel = ResolvePiecewiseChannel(config, "9000262001_Cabin_Pressure_Altitude_To_Instrument");
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = AMI9000262001HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateCabinPressureAltitudeOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] { _cabinPressureAltitudeInputSignal };
@@ -52,12 +118,23 @@ namespace SimLinkup.HardwareSupport.AMI
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            AMI9000262001HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new AMI9000262001HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "AMI9000262001HardwareSupportModule.config");
+                hsmConfig = AMI9000262001HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new AMI9000262001HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -140,6 +217,11 @@ namespace SimLinkup.HardwareSupport.AMI
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -171,32 +253,33 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void UpdateCabinPressureAltitudeOutputValues()
         {
-            if (_cabinPressureAltitudeInputSignal != null)
+            if (_cabinPressureAltitudeInputSignal == null) return;
+            if (_cabinPressureAltitudeOutputSignal == null) return;
+            var cabinPressureAltitudeInput = _cabinPressureAltitudeInputSignal.State;
+
+            // Editor override: piecewise channel.
+            if (_cabinAltChannel != null)
             {
-                var cabinPressureAltitudeInput = _cabinPressureAltitudeInputSignal.State;
-
-                var degrees = cabinPressureAltitudeInput < 0.0000
-                    ? 0.0000
-                    : (cabinPressureAltitudeInput >= 0 && cabinPressureAltitudeInput <= 50000.0000
-                        ? cabinPressureAltitudeInput / 50000.0000 * 300.0000
-                        : 300.0);
-
-                var cabinPressureAltitudeOutputValue = ((degrees / 300.00) * 20.00) - 10.00;
-
-                if (_cabinPressureAltitudeOutputSignal != null)
-                {
-                    if (cabinPressureAltitudeOutputValue < -10)
-                    {
-                        cabinPressureAltitudeOutputValue = -10;
-                    }
-                    else if (cabinPressureAltitudeOutputValue > 10)
-                    {
-                        cabinPressureAltitudeOutputValue = 10;
-                    }
-
-                    _cabinPressureAltitudeOutputSignal.State = cabinPressureAltitudeOutputValue;
-                }
+                var v = GaugeTransform.EvaluatePiecewise(
+                    cabinPressureAltitudeInput,
+                    _cabinAltChannel.Transform.Breakpoints);
+                _cabinPressureAltitudeOutputSignal.State = _cabinAltChannel.ApplyTrim(
+                    v,
+                    _cabinPressureAltitudeOutputSignal.MinValue,
+                    _cabinPressureAltitudeOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — 0..50000 ft → -10..+10 V linear.
+            var degrees = cabinPressureAltitudeInput < 0.0000
+                ? 0.0000
+                : (cabinPressureAltitudeInput >= 0 && cabinPressureAltitudeInput <= 50000.0000
+                    ? cabinPressureAltitudeInput / 50000.0000 * 300.0000
+                    : 300.0);
+            var cabinPressureAltitudeOutputValue = ((degrees / 300.00) * 20.00) - 10.00;
+            if (cabinPressureAltitudeOutputValue < -10) cabinPressureAltitudeOutputValue = -10;
+            else if (cabinPressureAltitudeOutputValue > 10) cabinPressureAltitudeOutputValue = 10;
+            _cabinPressureAltitudeOutputSignal.State = cabinPressureAltitudeOutputValue;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9000262001HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9000262001HardwareSupportModuleConfig.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.AMI
+{
+    // Per-gauge calibration config for AMI 90002620-01 (F-16 Cabin Pressure
+    // Altimeter). Single piecewise channel — 0..50000 ft → -10..+10 V linear.
+    [Serializable]
+    [XmlRoot(nameof(AMI9000262001HardwareSupportModule))]
+    public class AMI9000262001HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static AMI9000262001HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<AMI9000262001HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/AMI/AMI900158001HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI900158001HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16.HSI;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.AMI
 {
     //AMI 9001580-01 HSI
     public class AMI900158001HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(AMI900158001HardwareSupportModule));
         private readonly IHorizontalSituationIndicator _renderer = new HorizontalSituationIndicator();
         private AnalogSignal _bearingCOSOutputSignal;
         private AnalogSignal _bearingInputSignal;
@@ -65,12 +69,215 @@ namespace SimLinkup.HardwareSupport.AMI
         private DigitalSignal.SignalChangedEventHandler _toFlagInputSignalChangedEventHandler;
         private DigitalSignal _toFlagOutputSignal;
 
-        private AMI900158001HardwareSupportModule()
+        // Editor-authored calibration. Each output channel can be overridden
+        // independently — when an override is present, the channel uses
+        // EvaluatePiecewise/EvaluatePiecewiseResolver/EvaluateMultiTurnResolver
+        // + ApplyTrim. The two cross-coupled channels (bearing, heading)
+        // are deliberately NOT directly editable — their pointer geometry
+        // is computed from compass + their respective inputs, so the user
+        // calibrates them by tuning compass.
+        private AMI900158001HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _compassTransform;
+        private GaugeChannelConfig _compassSinChannel;
+        private GaugeChannelConfig _compassCosChannel;
+        private GaugeTransformConfig _courseTransform;
+        private GaugeChannelConfig _courseSinChannel;
+        private GaugeChannelConfig _courseCosChannel;
+        private GaugeChannelConfig _courseDeviationChannel;
+        private GaugeTransformConfig _dmeX100Transform;
+        private GaugeChannelConfig _dmeX100SinChannel;
+        private GaugeChannelConfig _dmeX100CosChannel;
+        private GaugeTransformConfig _dmeX10Transform;
+        private GaugeChannelConfig _dmeX10SinChannel;
+        private GaugeChannelConfig _dmeX10CosChannel;
+        private GaugeTransformConfig _dmeX1Transform;
+        private GaugeChannelConfig _dmeX1SinChannel;
+        private GaugeChannelConfig _dmeX1CosChannel;
+        private GaugeChannelConfig _offFlagChannel;
+        private GaugeChannelConfig _fromFlagChannel;
+        private GaugeChannelConfig _toFlagChannel;
+        private GaugeChannelConfig _deviationFlagChannel;
+        private GaugeChannelConfig _dmeShutterChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public AMI900158001HardwareSupportModule(AMI900158001HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "900158001_Compass_SIN_To_Instrument",
+                "900158001_Compass_COS_To_Instrument",
+                out _compassTransform, out _compassSinChannel, out _compassCosChannel);
+            ResolvePiecewiseResolverPair(config,
+                "900158001_Course_SIN_To_Instrument",
+                "900158001_Course_COS_To_Instrument",
+                out _courseTransform, out _courseSinChannel, out _courseCosChannel);
+            _courseDeviationChannel = ResolvePiecewiseChannel(config, "900158001_Course_Deviation_To_Instrument");
+            ResolveMultiResolverPair(config,
+                "900158001_DME_x100_SIN_To_Instrument",
+                "900158001_DME_x100_COS_To_Instrument",
+                out _dmeX100Transform, out _dmeX100SinChannel, out _dmeX100CosChannel);
+            ResolveMultiResolverPair(config,
+                "900158001_DME_x10_SIN_To_Instrument",
+                "900158001_DME_x10_COS_To_Instrument",
+                out _dmeX10Transform, out _dmeX10SinChannel, out _dmeX10CosChannel);
+            ResolveMultiResolverPair(config,
+                "900158001_DME_x1_SIN_To_Instrument",
+                "900158001_DME_x1_COS_To_Instrument",
+                out _dmeX1Transform, out _dmeX1SinChannel, out _dmeX1CosChannel);
+            _offFlagChannel       = ResolveDigitalInvertChannel(config, "900158001_OFF_Flag_To_Instrument");
+            _fromFlagChannel      = ResolveDigitalInvertChannel(config, "900158001_FROM_Flag_To_Instrument");
+            _toFlagChannel        = ResolveDigitalInvertChannel(config, "900158001_TO_Flag_To_Instrument");
+            _deviationFlagChannel = ResolveDigitalInvertChannel(config, "900158001_Deviation_Flag_To_Instrument");
+            _dmeShutterChannel    = ResolveDigitalInvertChannel(config, "900158001_DME_Shutter_To_Instrument");
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private static void ResolveMultiResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "multi_resolver"
+                || !t.UnitsPerRevolution.HasValue
+                || t.UnitsPerRevolution.Value == 0
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private static GaugeChannelConfig ResolveDigitalInvertChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "digital_invert"
+                && ch.Invert.HasValue)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = AMI900158001HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateBearingOutputValue();
+                UpdateCompassOutputValue();
+                UpdateCourseDeviationOutputValue();
+                UpdateCourseOutputValue();
+                UpdateDeviationFlagOutputValue();
+                UpdateDMEOutputValue();
+                UpdateDMEShutterOutputValue();
+                UpdateFromFlagOutputValue();
+                UpdateHeadingOutputValue();
+                UpdateOffFlagOutputValue();
+                UpdateToFlagOutputValue();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+        }
+
+        private static bool ApplyDigitalInvert(GaugeChannelConfig ch, bool input)
+        {
+            return ch.Invert.Value ? !input : input;
         }
 
         public override AnalogSignal[] AnalogInputs => new[]
@@ -100,7 +307,7 @@ namespace SimLinkup.HardwareSupport.AMI
         };
 
         public override string FriendlyName =>
-            "AMI P/N 900150-01 - Indicator - Simulated Horizontal Situation Indicator";
+            "AMI P/N 9001580-01 - Indicator - Simulated Horizontal Situation Indicator";
 
         public void Dispose()
         {
@@ -115,8 +322,23 @@ namespace SimLinkup.HardwareSupport.AMI
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule> {new AMI900158001HardwareSupportModule()};
-            return toReturn.ToArray();
+            AMI900158001HardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "AMI900158001HardwareSupportModule.config");
+                hsmConfig = AMI900158001HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new AMI900158001HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -858,6 +1080,11 @@ namespace SimLinkup.HardwareSupport.AMI
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -1102,6 +1329,18 @@ namespace SimLinkup.HardwareSupport.AMI
                 return;
             }
             var compassDegrees = _compassInputSignal.State;
+
+            // Editor override: piecewise_resolver pair.
+            if (_compassTransform != null && _compassSinChannel != null && _compassCosChannel != null)
+            {
+                var t = _compassTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    compassDegrees, t.Breakpoints, t.PeakVolts.Value);
+                _compassSINOutputSignal.State = _compassSinChannel.ApplyTrim(sinCos[0], _compassSINOutputSignal.MinValue, _compassSINOutputSignal.MaxValue);
+                _compassCOSOutputSignal.State = _compassCosChannel.ApplyTrim(sinCos[1], _compassCOSOutputSignal.MinValue, _compassCOSOutputSignal.MaxValue);
+                return;
+            }
+
             var compassSINOutputValue = 10.0000 * Math.Sin(compassDegrees * Constants.RADIANS_PER_DEGREE);
             if (compassSINOutputValue < -10)
             {
@@ -1135,6 +1374,18 @@ namespace SimLinkup.HardwareSupport.AMI
                 return;
             }
             var courseDeviationDegrees = _courseDeviationInputSignal.State;
+
+            // Editor override: piecewise channel. Note this consumes the
+            // RAW deviation degrees (not normalized to limit) — the user's
+            // breakpoint table defines the input → output mapping directly,
+            // so the user encodes whatever limit they want into the table.
+            if (_courseDeviationChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(courseDeviationDegrees, _courseDeviationChannel.Transform.Breakpoints);
+                _courseDeviationOutputSignal.State = _courseDeviationChannel.ApplyTrim(v, _courseDeviationOutputSignal.MinValue, _courseDeviationOutputSignal.MaxValue);
+                return;
+            }
+
             var courseDeviationLimitDegrees = _courseDeviationLimitInputSignal.State;
             if (courseDeviationLimitDegrees == 0 || double.IsInfinity(courseDeviationLimitDegrees) ||
                 double.IsNaN(courseDeviationLimitDegrees))
@@ -1160,6 +1411,18 @@ namespace SimLinkup.HardwareSupport.AMI
             if (_courseInputSignal != null && _courseSINOutputSignal != null && _courseCOSOutputSignal != null)
             {
                 var desiredCourseDegrees = _courseInputSignal.State;
+
+                // Editor override: piecewise_resolver pair.
+                if (_courseTransform != null && _courseSinChannel != null && _courseCosChannel != null)
+                {
+                    var t = _courseTransform;
+                    var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                        desiredCourseDegrees, t.Breakpoints, t.PeakVolts.Value);
+                    _courseSINOutputSignal.State = _courseSinChannel.ApplyTrim(sinCos[0], _courseSINOutputSignal.MinValue, _courseSINOutputSignal.MaxValue);
+                    _courseCOSOutputSignal.State = _courseCosChannel.ApplyTrim(sinCos[1], _courseCOSOutputSignal.MinValue, _courseCOSOutputSignal.MaxValue);
+                    return;
+                }
+
                 var courseSINOutputValue = 10.0000 * Math.Sin(desiredCourseDegrees * Constants.RADIANS_PER_DEGREE);
                 if (courseSINOutputValue < -10)
                 {
@@ -1186,10 +1449,9 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void UpdateDeviationFlagOutputValue()
         {
-            if (_deviationFlagInputSignal != null && _deviationFlagOutputSignal != null)
-            {
-                _deviationFlagOutputSignal.State = _deviationFlagInputSignal.State;
-            }
+            if (_deviationFlagInputSignal == null || _deviationFlagOutputSignal == null) return;
+            if (_deviationFlagChannel != null) { _deviationFlagOutputSignal.State = ApplyDigitalInvert(_deviationFlagChannel, _deviationFlagInputSignal.State); return; }
+            _deviationFlagOutputSignal.State = _deviationFlagInputSignal.State;
         }
 
         private void UpdateDMEOutputValue()
@@ -1214,6 +1476,26 @@ namespace SimLinkup.HardwareSupport.AMI
             var DMEx100 = byte.Parse(distanceToBeaconString.Substring(0, 1));
             var DMEx10 = byte.Parse(distanceToBeaconString.Substring(1, 1));
             var DMEx1 = byte.Parse(distanceToBeaconString.Substring(2, 1));
+
+            // Editor overrides: each digit drum is an independent multi_resolver.
+            // When all three pairs have overrides we route through them; when
+            // any pair doesn't, the legacy hardcoded math runs for ALL three
+            // (preserves the original all-or-nothing behavior).
+            if (_dmeX100Transform != null && _dmeX100SinChannel != null && _dmeX100CosChannel != null
+                && _dmeX10Transform != null && _dmeX10SinChannel != null && _dmeX10CosChannel != null
+                && _dmeX1Transform != null && _dmeX1SinChannel != null && _dmeX1CosChannel != null)
+            {
+                var sc100 = GaugeTransform.EvaluateMultiTurnResolver(DMEx100, _dmeX100Transform.UnitsPerRevolution.Value, _dmeX100Transform.PeakVolts.Value);
+                var sc10  = GaugeTransform.EvaluateMultiTurnResolver(DMEx10,  _dmeX10Transform.UnitsPerRevolution.Value,  _dmeX10Transform.PeakVolts.Value);
+                var sc1   = GaugeTransform.EvaluateMultiTurnResolver(DMEx1,   _dmeX1Transform.UnitsPerRevolution.Value,   _dmeX1Transform.PeakVolts.Value);
+                _DMEx100SINOutputSignal.State = _dmeX100SinChannel.ApplyTrim(sc100[0], _DMEx100SINOutputSignal.MinValue, _DMEx100SINOutputSignal.MaxValue);
+                _DMEx100COSOutputSignal.State = _dmeX100CosChannel.ApplyTrim(sc100[1], _DMEx100COSOutputSignal.MinValue, _DMEx100COSOutputSignal.MaxValue);
+                _DMEx10SINOutputSignal.State  = _dmeX10SinChannel.ApplyTrim(sc10[0], _DMEx10SINOutputSignal.MinValue, _DMEx10SINOutputSignal.MaxValue);
+                _DMEx10COSOutputSignal.State  = _dmeX10CosChannel.ApplyTrim(sc10[1], _DMEx10COSOutputSignal.MinValue, _DMEx10COSOutputSignal.MaxValue);
+                _DMEx1SINOutputSignal.State   = _dmeX1SinChannel.ApplyTrim(sc1[0], _DMEx1SINOutputSignal.MinValue, _DMEx1SINOutputSignal.MaxValue);
+                _DMEx1COSOutputSignal.State   = _dmeX1CosChannel.ApplyTrim(sc1[1], _DMEx1COSOutputSignal.MinValue, _DMEx1COSOutputSignal.MaxValue);
+                return;
+            }
 
             var DMEx100SINOutputValue = 10.0000 * Math.Sin(DMEx100 / 10.0000 * 360.0000 * Constants.RADIANS_PER_DEGREE);
             if (DMEx100SINOutputValue < -10)
@@ -1286,18 +1568,16 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void UpdateDMEShutterOutputValue()
         {
-            if (_dmeShutterInputSignal != null && _dmeShutterOutputSignal != null)
-            {
-                _dmeShutterOutputSignal.State = _dmeShutterInputSignal.State;
-            }
+            if (_dmeShutterInputSignal == null || _dmeShutterOutputSignal == null) return;
+            if (_dmeShutterChannel != null) { _dmeShutterOutputSignal.State = ApplyDigitalInvert(_dmeShutterChannel, _dmeShutterInputSignal.State); return; }
+            _dmeShutterOutputSignal.State = _dmeShutterInputSignal.State;
         }
 
         private void UpdateFromFlagOutputValue()
         {
-            if (_fromFlagInputSignal != null && _fromFlagOutputSignal != null)
-            {
-                _fromFlagOutputSignal.State = _fromFlagInputSignal.State;
-            }
+            if (_fromFlagInputSignal == null || _fromFlagOutputSignal == null) return;
+            if (_fromFlagChannel != null) { _fromFlagOutputSignal.State = ApplyDigitalInvert(_fromFlagChannel, _fromFlagInputSignal.State); return; }
+            _fromFlagOutputSignal.State = _fromFlagInputSignal.State;
         }
 
         private void UpdateHeadingOutputValue()
@@ -1337,18 +1617,16 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void UpdateOffFlagOutputValue()
         {
-            if (_offFlagInputSignal != null && _offFlagOutputSignal != null)
-            {
-                _offFlagOutputSignal.State = _offFlagInputSignal.State;
-            }
+            if (_offFlagInputSignal == null || _offFlagOutputSignal == null) return;
+            if (_offFlagChannel != null) { _offFlagOutputSignal.State = ApplyDigitalInvert(_offFlagChannel, _offFlagInputSignal.State); return; }
+            _offFlagOutputSignal.State = _offFlagInputSignal.State;
         }
 
         private void UpdateToFlagOutputValue()
         {
-            if (_toFlagInputSignal != null && _toFlagOutputSignal != null)
-            {
-                _toFlagOutputSignal.State = _toFlagInputSignal.State;
-            }
+            if (_toFlagInputSignal == null || _toFlagOutputSignal == null) return;
+            if (_toFlagChannel != null) { _toFlagOutputSignal.State = ApplyDigitalInvert(_toFlagChannel, _toFlagInputSignal.State); return; }
+            _toFlagOutputSignal.State = _toFlagInputSignal.State;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/AMI/AMI900158001HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI900158001HardwareSupportModuleConfig.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.AMI
+{
+    // Per-gauge calibration config for AMI 9001580-01 (F-16 HSI). 11 direct
+    // calibratable channels:
+    //
+    //   - Compass SIN/COS pair         (piecewise_resolver, identity 0..360°)
+    //   - Course SIN/COS pair          (piecewise_resolver, identity 0..360°)
+    //   - Course Deviation             (piecewise — linear, ±limit × ±10 V)
+    //   - DME × 100 SIN/COS pair       (multi_resolver, 10 digit-units/rev)
+    //   - DME × 10  SIN/COS pair       (multi_resolver, 10 digit-units/rev)
+    //   - DME × 1   SIN/COS pair       (multi_resolver, 10 digit-units/rev)
+    //   - 5 digital flags              (digital_invert × 5: pass-through)
+    //
+    // Two channels are NOT directly calibratable because their output is
+    // CROSS-COUPLED to other inputs:
+    //   - Bearing SIN/COS — depends on (compass, bearing-to-beacon)
+    //   - Heading SIN/COS — depends on (compass, desired-heading)
+    // The cross-coupling math stays hardcoded in the HSM. Users calibrate
+    // these by tuning the compass channel; the bearing/heading pointers
+    // follow geometrically.
+    [Serializable]
+    [XmlRoot(nameof(AMI900158001HardwareSupportModule))]
+    public class AMI900158001HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static AMI900158001HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<AMI900158001HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9001584HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9001584HardwareSupportModule.cs
@@ -1,17 +1,22 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.AMI
 {
     //AMI 9001584 F-16 Simulated Fuel Quantity Indicator
     public class AMI9001584HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(AMI9001584HardwareSupportModule));
         private readonly IFuelQuantityIndicator _renderer = new FuelQuantityIndicator();
+
         private AnalogSignal _aftLeftFuelInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _aftLeftFuelInputSignalChangedEventHandler;
         private AnalogSignal _aftLeftOutputSignal;
@@ -19,18 +24,84 @@ namespace SimLinkup.HardwareSupport.AMI
         private AnalogSignal _foreRightFuelInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _foreRightFuelInputSignalChangedEventHandler;
         private AnalogSignal _foreRightOutputSignal;
-
         private bool _isDisposed;
         private AnalogSignal _totalFuelInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _totalFuelInputSignalChangedEventHandler;
 
-        private AMI9001584HardwareSupportModule()
+        private AMI9001584HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _counterChannel;
+        private GaugeChannelConfig _aftLeftChannel;
+        private GaugeChannelConfig _foreRightChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public AMI9001584HardwareSupportModule(AMI9001584HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
             UpdateOutputValues();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _counterChannel  = ResolvePiecewiseChannel(config, "9001584_Counter_To_Instrument");
+            _aftLeftChannel  = ResolvePiecewiseChannel(config, "9001584_AL_To_Instrument");
+            _foreRightChannel = ResolvePiecewiseChannel(config, "9001584_FR_To_Instrument");
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = AMI9001584HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[]
@@ -58,11 +129,23 @@ namespace SimLinkup.HardwareSupport.AMI
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            AMI9001584HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new AMI9001584HardwareSupportModule()
-            };
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "AMI9001584HardwareSupportModule.config");
+                hsmConfig = AMI9001584HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new AMI9001584HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -231,6 +314,11 @@ namespace SimLinkup.HardwareSupport.AMI
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -269,8 +357,6 @@ namespace SimLinkup.HardwareSupport.AMI
                 {
                 }
             }
-
-
             if (_aftLeftFuelInputSignalChangedEventHandler != null && _aftLeftFuelInputSignal != null)
             {
                 try
@@ -295,21 +381,53 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void UpdateOutputValues()
         {
-            //NOTE: these values are correct for Nigel's modification to the AMI 9001584 to replace the 1-turn pot with a 3-turn pot for the needles to widen the range of indicated values
+            // F/R pointer: piecewise override or legacy linear (3-turn pot, ±7 V).
             if (_foreRightOutputSignal != null)
             {
-                _foreRightOutputSignal.State = _foreRightFuelInputSignal.State / 100.00 / 42.00 * 14.00 -
-                                               7.00; //zero indicated at -7.00V; 4200 lbs indicated at +7V
+                if (_foreRightChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _foreRightFuelInputSignal.State,
+                        _foreRightChannel.Transform.Breakpoints);
+                    _foreRightOutputSignal.State = _foreRightChannel.ApplyTrim(v, _foreRightOutputSignal.MinValue, _foreRightOutputSignal.MaxValue);
+                }
+                else
+                {
+                    //NOTE: these values are correct for Nigel's modification to the AMI 9001584 to replace the 1-turn pot with a 3-turn pot for the needles to widen the range of indicated values
+                    _foreRightOutputSignal.State = _foreRightFuelInputSignal.State / 100.00 / 42.00 * 14.00 - 7.00;
+                }
             }
+
+            // A/L pointer: piecewise override or legacy linear.
             if (_aftLeftOutputSignal != null)
             {
-                _aftLeftOutputSignal.State =
-                    _aftLeftFuelInputSignal.State / 100.00 / 42.00 * 14.00 -
-                    7.00; //zero indicated at -7.00V; 4200 lbs indicated at +7V
+                if (_aftLeftChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _aftLeftFuelInputSignal.State,
+                        _aftLeftChannel.Transform.Breakpoints);
+                    _aftLeftOutputSignal.State = _aftLeftChannel.ApplyTrim(v, _aftLeftOutputSignal.MinValue, _aftLeftOutputSignal.MaxValue);
+                }
+                else
+                {
+                    _aftLeftOutputSignal.State = _aftLeftFuelInputSignal.State / 100.00 / 42.00 * 14.00 - 7.00;
+                }
             }
+
+            // Counter: piecewise override or hardcoded linear (18000 max).
             if (_counterOutputSignal != null)
             {
-                _counterOutputSignal.State = _totalFuelInputSignal.State / 18000 * 20.00 - 10.00;
+                if (_counterChannel != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(
+                        _totalFuelInputSignal.State,
+                        _counterChannel.Transform.Breakpoints);
+                    _counterOutputSignal.State = _counterChannel.ApplyTrim(v, _counterOutputSignal.MinValue, _counterOutputSignal.MaxValue);
+                }
+                else
+                {
+                    _counterOutputSignal.State = _totalFuelInputSignal.State / 18000 * 20.00 - 10.00;
+                }
             }
         }
     }

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9001584HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9001584HardwareSupportModuleConfig.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.AMI
+{
+    // Per-gauge calibration config for AMI 9001584 (F-16 Fuel Quantity
+    // Indicator). Three piecewise channels — counter (0..18000 lbs) +
+    // AL/FR pointers (0..4200 lbs each, ±7 V swing for the Nigel-modded
+    // 3-turn pot variant). No legacy bare-property fields.
+    [Serializable]
+    [XmlRoot(nameof(AMI9001584HardwareSupportModule))]
+    public class AMI9001584HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static AMI9001584HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<AMI9001584HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9002780-02HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9002780-02HardwareSupportModule.cs
@@ -1,24 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.AMI
 {
     //AMI 9002780-02 Primary ADI
     public class AMI900278002HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(AMI900278002HardwareSupportModule));
         private const float GLIDESLOPE_DEVIATION_LIMIT_DEGREES = 1.0F;
         private const float LOCALIZER_DEVIATION_LIMIT_DEGREES = 5.0F;
 
         private readonly IADI _renderer = new ADI();
         private DigitalSignal _auxFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _auxFlagInputSignalChangedEventHandler;
-
         private DigitalSignal _auxFlagOutputSignal;
         private DigitalSignal _gsFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _gsFlagInputSignalChangedEventHandler;
@@ -26,7 +29,6 @@ namespace SimLinkup.HardwareSupport.AMI
         private AnalogSignal _horizontalCommandBarInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _horizontalCommandBarInputSignalChangedEventHandler;
         private AnalogSignal _horizontalCommandBarOutputSignal;
-
         private bool _isDisposed;
         private DigitalSignal _locFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _locFlagInputSignalChangedEventHandler;
@@ -34,10 +36,8 @@ namespace SimLinkup.HardwareSupport.AMI
         private DigitalSignal _offFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _offFlagInputSignalChangedEventHandler;
         private DigitalSignal _offFlagOutputSignal;
-
         private AnalogSignal _pitchInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _pitchInputSignalChangedEventHandler;
-
         private AnalogSignal _pitchOutputSignal;
         private AnalogSignal _rateOfTurnInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _rateOfTurnInputSignalChangedEventHandler;
@@ -46,18 +46,153 @@ namespace SimLinkup.HardwareSupport.AMI
         private AnalogSignal _rollInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _rollInputSignalChangedEventHandler;
         private AnalogSignal _rollSinOutputSignal;
-
         private DigitalSignal _showCommandBarsInputSignal;
         private AnalogSignal _verticalCommandBarInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _verticalCommandBarInputSignalChangedEventHandler;
         private AnalogSignal _verticalCommandBarOutputSignal;
 
-        private AMI900278002HardwareSupportModule()
+        private AMI900278002HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _pitchChannel;
+        private GaugeTransformConfig _rollTransform;
+        private GaugeChannelConfig _rollSinChannel;
+        private GaugeChannelConfig _rollCosChannel;
+        private GaugeChannelConfig _offFlagChannel;
+        private GaugeChannelConfig _gsFlagChannel;
+        private GaugeChannelConfig _locFlagChannel;
+        private GaugeChannelConfig _auxFlagChannel;
+        private GaugeChannelConfig _horizontalCommandBarChannel;
+        private GaugeChannelConfig _verticalCommandBarChannel;
+        private GaugeChannelConfig _rateOfTurnChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public AMI900278002HardwareSupportModule(AMI900278002HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _pitchChannel = ResolvePiecewiseChannel(config, "900278002_Pitch_To_Instrument");
+            ResolvePiecewiseResolverPair(config,
+                "900278002_Roll_SIN_To_Instrument",
+                "900278002_Roll_COS_To_Instrument",
+                out _rollTransform, out _rollSinChannel, out _rollCosChannel);
+            _offFlagChannel = ResolveDigitalInvertChannel(config, "900278002_OFF_Flag_To_Instrument");
+            _gsFlagChannel  = ResolveDigitalInvertChannel(config, "900278002_GS_Flag_To_Instrument");
+            _locFlagChannel = ResolveDigitalInvertChannel(config, "900278002_LOC_Flag_To_Instrument");
+            _auxFlagChannel = ResolveDigitalInvertChannel(config, "900278002_AUX_Flag_To_Instrument");
+            _horizontalCommandBarChannel = ResolvePiecewiseChannel(config, "900278002_Horizontal_Command_Bar_To_Instrument");
+            _verticalCommandBarChannel   = ResolvePiecewiseChannel(config, "900278002_Vertical_Command_Bar_To_Instrument");
+            _rateOfTurnChannel = ResolvePiecewiseChannel(config, "900278002_Rate_Of_Turn_To_Instrument");
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private static GaugeChannelConfig ResolveDigitalInvertChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "digital_invert"
+                && ch.Invert.HasValue)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = AMI900278002HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateAuxFlagOutputValue();
+                UpdateGSFlagOutputValue();
+                UpdateLOCFlagOutputValue();
+                UpdateOFFFlagOutputValue();
+                UpdateHorizontalCommandBarOutputValues();
+                UpdatePitchOutputValues();
+                UpdateRateOfTurnOutputValues();
+                UpdateRollOutputValues();
+                UpdateVerticalCommandBarOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[]
@@ -96,11 +231,23 @@ namespace SimLinkup.HardwareSupport.AMI
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            AMI900278002HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new AMI900278002HardwareSupportModule()
-            };
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "AMI900278002HardwareSupportModule.config");
+                hsmConfig = AMI900278002HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new AMI900278002HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -248,16 +395,11 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void CreateInputEventHandlers()
         {
-            _pitchInputSignalChangedEventHandler =
-                pitch_InputSignalChanged;
-            _rollInputSignalChangedEventHandler =
-                roll_InputSignalChanged;
-            _horizontalCommandBarInputSignalChangedEventHandler =
-                horizontalCommandBar_InputSignalChanged;
-            _verticalCommandBarInputSignalChangedEventHandler =
-                verticalCommandBar_InputSignalChanged;
-            _rateOfTurnInputSignalChangedEventHandler =
-                rateOfTurn_InputSignalChanged;
+            _pitchInputSignalChangedEventHandler = pitch_InputSignalChanged;
+            _rollInputSignalChangedEventHandler = roll_InputSignalChanged;
+            _horizontalCommandBarInputSignalChangedEventHandler = horizontalCommandBar_InputSignalChanged;
+            _verticalCommandBarInputSignalChangedEventHandler = verticalCommandBar_InputSignalChanged;
+            _rateOfTurnInputSignalChangedEventHandler = rateOfTurn_InputSignalChanged;
             _auxFlagInputSignalChangedEventHandler = auxFlag_InputSignalChanged;
             _gsFlagInputSignalChangedEventHandler = gsFlag_InputSignalChanged;
             _locFlagInputSignalChangedEventHandler = locFlag_InputSignalChanged;
@@ -577,6 +719,11 @@ namespace SimLinkup.HardwareSupport.AMI
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -614,42 +761,20 @@ namespace SimLinkup.HardwareSupport.AMI
 
         private void RegisterForInputEvents()
         {
-            if (_auxFlagInputSignal != null)
-            {
-                _auxFlagInputSignal.SignalChanged += _auxFlagInputSignalChangedEventHandler;
-            }
-            if (_gsFlagInputSignal != null)
-            {
-                _gsFlagInputSignal.SignalChanged += _gsFlagInputSignalChangedEventHandler;
-            }
-            if (_locFlagInputSignal != null)
-            {
-                _locFlagInputSignal.SignalChanged += _locFlagInputSignalChangedEventHandler;
-            }
-            if (_offFlagInputSignal != null)
-            {
-                _offFlagInputSignal.SignalChanged += _offFlagInputSignalChangedEventHandler;
-            }
-            if (_pitchInputSignal != null)
-            {
-                _pitchInputSignal.SignalChanged += _pitchInputSignalChangedEventHandler;
-            }
-            if (_rollInputSignal != null)
-            {
-                _rollInputSignal.SignalChanged += _rollInputSignalChangedEventHandler;
-            }
-            if (_horizontalCommandBarInputSignal != null)
-            {
-                _horizontalCommandBarInputSignal.SignalChanged += _horizontalCommandBarInputSignalChangedEventHandler;
-            }
-            if (_verticalCommandBarInputSignal != null)
-            {
-                _verticalCommandBarInputSignal.SignalChanged += _verticalCommandBarInputSignalChangedEventHandler;
-            }
-            if (_rateOfTurnInputSignal != null)
-            {
-                _rateOfTurnInputSignal.SignalChanged += _rateOfTurnInputSignalChangedEventHandler;
-            }
+            // NOTE: original C# never registered _showCommandBarsInputSignal —
+            // changes to that flag don't trigger a re-render. Preserved to
+            // avoid behavior drift; users who need bars to hide/show
+            // dynamically can update one of the bar inputs to force an
+            // update.
+            if (_auxFlagInputSignal != null) { _auxFlagInputSignal.SignalChanged += _auxFlagInputSignalChangedEventHandler; }
+            if (_gsFlagInputSignal != null) { _gsFlagInputSignal.SignalChanged += _gsFlagInputSignalChangedEventHandler; }
+            if (_locFlagInputSignal != null) { _locFlagInputSignal.SignalChanged += _locFlagInputSignalChangedEventHandler; }
+            if (_offFlagInputSignal != null) { _offFlagInputSignal.SignalChanged += _offFlagInputSignalChangedEventHandler; }
+            if (_pitchInputSignal != null) { _pitchInputSignal.SignalChanged += _pitchInputSignalChangedEventHandler; }
+            if (_rollInputSignal != null) { _rollInputSignal.SignalChanged += _rollInputSignalChangedEventHandler; }
+            if (_horizontalCommandBarInputSignal != null) { _horizontalCommandBarInputSignal.SignalChanged += _horizontalCommandBarInputSignalChangedEventHandler; }
+            if (_verticalCommandBarInputSignal != null) { _verticalCommandBarInputSignal.SignalChanged += _verticalCommandBarInputSignalChangedEventHandler; }
+            if (_rateOfTurnInputSignal != null) { _rateOfTurnInputSignal.SignalChanged += _rateOfTurnInputSignalChangedEventHandler; }
         }
 
         private void roll_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
@@ -657,259 +782,202 @@ namespace SimLinkup.HardwareSupport.AMI
             UpdateRollOutputValues();
         }
 
+        private void verticalCommandBar_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateVerticalCommandBarOutputValues();
+        }
+
         private void UnregisterForInputEvents()
         {
-            if (_auxFlagInputSignal != null)
-            {
-                try
-                {
-                    _auxFlagInputSignal.SignalChanged -= _auxFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_gsFlagInputSignal != null)
-            {
-                try
-                {
-                    _gsFlagInputSignal.SignalChanged -= _gsFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_locFlagInputSignal != null)
-            {
-                try
-                {
-                    _locFlagInputSignal.SignalChanged -= _locFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_offFlagInputSignal != null)
-            {
-                try
-                {
-                    _offFlagInputSignal.SignalChanged -= _offFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_pitchInputSignalChangedEventHandler != null && _pitchInputSignal != null)
-            {
-                try
-                {
-                    _pitchInputSignal.SignalChanged -= _pitchInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_rollInputSignalChangedEventHandler != null && _rollInputSignal != null)
-            {
-                try
-                {
-                    _rollInputSignal.SignalChanged -= _rollInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_horizontalCommandBarInputSignalChangedEventHandler != null && _horizontalCommandBarInputSignal != null)
-            {
-                try
-                {
-                    _horizontalCommandBarInputSignal.SignalChanged -=
-                        _horizontalCommandBarInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_verticalCommandBarInputSignalChangedEventHandler != null && _verticalCommandBarInputSignal != null)
-            {
-                try
-                {
-                    _verticalCommandBarInputSignal.SignalChanged -= _verticalCommandBarInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_rateOfTurnInputSignalChangedEventHandler != null && _rateOfTurnInputSignal != null)
-            {
-                try
-                {
-                    _rateOfTurnInputSignal.SignalChanged -= _rateOfTurnInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
+            try { if (_auxFlagInputSignal != null) _auxFlagInputSignal.SignalChanged -= _auxFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_gsFlagInputSignal != null) _gsFlagInputSignal.SignalChanged -= _gsFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_locFlagInputSignal != null) _locFlagInputSignal.SignalChanged -= _locFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_offFlagInputSignal != null) _offFlagInputSignal.SignalChanged -= _offFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_pitchInputSignal != null) _pitchInputSignal.SignalChanged -= _pitchInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_rollInputSignal != null) _rollInputSignal.SignalChanged -= _rollInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_horizontalCommandBarInputSignal != null) _horizontalCommandBarInputSignal.SignalChanged -= _horizontalCommandBarInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_verticalCommandBarInputSignal != null) _verticalCommandBarInputSignal.SignalChanged -= _verticalCommandBarInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_rateOfTurnInputSignal != null) _rateOfTurnInputSignal.SignalChanged -= _rateOfTurnInputSignalChangedEventHandler; } catch (RemotingException) { }
+        }
+
+        private static bool ApplyDigitalInvert(GaugeChannelConfig ch, bool input)
+        {
+            return ch.Invert.Value ? !input : input;
         }
 
         private void UpdateAuxFlagOutputValue()
         {
+            if (_auxFlagOutputSignal == null) return;
+            if (_auxFlagChannel != null) { _auxFlagOutputSignal.State = ApplyDigitalInvert(_auxFlagChannel, _auxFlagInputSignal.State); return; }
             _auxFlagOutputSignal.State = !_auxFlagInputSignal.State;
         }
 
         private void UpdateGSFlagOutputValue()
         {
+            if (_gsFlagOutputSignal == null) return;
+            if (_gsFlagChannel != null) { _gsFlagOutputSignal.State = ApplyDigitalInvert(_gsFlagChannel, _gsFlagInputSignal.State); return; }
             _gsFlagOutputSignal.State = !_gsFlagInputSignal.State;
-        }
-
-        private void UpdateHorizontalCommandBarOutputValues()
-        {
-            if (_horizontalCommandBarInputSignal != null)
-            {
-                var percentDeflection = _horizontalCommandBarInputSignal.State;
-
-                var outputValue = _showCommandBarsInputSignal.State ? 4 * percentDeflection : 10;
-
-                if (_horizontalCommandBarOutputSignal != null)
-                {
-                    if (outputValue < -10)
-                    {
-                        outputValue = -10;
-                    }
-                    else if (outputValue > 10)
-                    {
-                        outputValue = 10;
-                    }
-
-                    _horizontalCommandBarOutputSignal.State = outputValue;
-                }
-            }
         }
 
         private void UpdateLOCFlagOutputValue()
         {
+            if (_locFlagOutputSignal == null) return;
+            if (_locFlagChannel != null) { _locFlagOutputSignal.State = ApplyDigitalInvert(_locFlagChannel, _locFlagInputSignal.State); return; }
             _locFlagOutputSignal.State = !_locFlagInputSignal.State;
         }
 
         private void UpdateOFFFlagOutputValue()
         {
+            if (_offFlagOutputSignal == null) return;
+            if (_offFlagChannel != null) { _offFlagOutputSignal.State = ApplyDigitalInvert(_offFlagChannel, _offFlagInputSignal.State); return; }
             _offFlagOutputSignal.State = !_offFlagInputSignal.State;
+        }
+
+        private void UpdateHorizontalCommandBarOutputValues()
+        {
+            if (_horizontalCommandBarInputSignal == null) return;
+            if (_horizontalCommandBarOutputSignal == null) return;
+
+            // Show/hide gating preserved verbatim.
+            if (!_showCommandBarsInputSignal.State)
+            {
+                _horizontalCommandBarOutputSignal.State = 10;
+                return;
+            }
+
+            var percentDeflection = _horizontalCommandBarInputSignal.State;
+
+            if (_horizontalCommandBarChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _horizontalCommandBarChannel.Transform.Breakpoints);
+                _horizontalCommandBarOutputSignal.State = _horizontalCommandBarChannel.ApplyTrim(v, _horizontalCommandBarOutputSignal.MinValue, _horizontalCommandBarOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — input × 4.
+            var outputValue = 4 * percentDeflection;
+            if (outputValue < -10) outputValue = -10;
+            else if (outputValue > 10) outputValue = 10;
+            _horizontalCommandBarOutputSignal.State = outputValue;
         }
 
         private void UpdatePitchOutputValues()
         {
-            if (_pitchInputSignal != null)
+            if (_pitchInputSignal == null) return;
+            if (_pitchOutputSignal == null) return;
+            var pitchInputDegrees = _pitchInputSignal.State;
+
+            if (_pitchChannel != null)
             {
-                var pitchInputDegrees = _pitchInputSignal.State;
-
-                var pitchOutputValue = 10.0000 * (pitchInputDegrees / 90.0);
-
-                if (_pitchOutputSignal != null)
-                {
-                    if (pitchOutputValue < -10)
-                    {
-                        pitchOutputValue = -10;
-                    }
-                    else if (pitchOutputValue > 10)
-                    {
-                        pitchOutputValue = 10;
-                    }
-
-                    _pitchOutputSignal.State = pitchOutputValue;
-                }
+                var v = GaugeTransform.EvaluatePiecewise(pitchInputDegrees, _pitchChannel.Transform.Breakpoints);
+                _pitchOutputSignal.State = _pitchChannel.ApplyTrim(v, _pitchOutputSignal.MinValue, _pitchOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — linear ±90° → ±10 V.
+            var pitchOutputValue = 10.0000 * (pitchInputDegrees / 90.0);
+            if (pitchOutputValue < -10) pitchOutputValue = -10;
+            else if (pitchOutputValue > 10) pitchOutputValue = 10;
+            _pitchOutputSignal.State = pitchOutputValue;
         }
 
         private void UpdateRateOfTurnOutputValues()
         {
-            if (_rateOfTurnInputSignal != null)
+            if (_rateOfTurnInputSignal == null) return;
+            if (_rateOfTurnOutputSignal == null) return;
+            var percentDeflection = _rateOfTurnInputSignal.State;
+
+            if (_rateOfTurnChannel != null)
             {
-                var percentDeflection = _rateOfTurnInputSignal.State;
-
-                var outputValue = 10.0000 * percentDeflection;
-
-                if (_rateOfTurnOutputSignal == null) return;
-                if (outputValue < -10)
-                {
-                    outputValue = -10;
-                }
-                else if (outputValue > 10)
-                {
-                    outputValue = 0;
-                }
-
-                _rateOfTurnOutputSignal.State = outputValue;
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _rateOfTurnChannel.Transform.Breakpoints);
+                _rateOfTurnOutputSignal.State = _rateOfTurnChannel.ApplyTrim(v, _rateOfTurnOutputSignal.MinValue, _rateOfTurnOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — preserves original `else if (out > 10) out = 0`
+            // behavior verbatim.
+            var outputValue = 10.0000 * percentDeflection;
+            if (outputValue < -10)
+            {
+                outputValue = -10;
+            }
+            else if (outputValue > 10)
+            {
+                outputValue = 0;
+            }
+            _rateOfTurnOutputSignal.State = outputValue;
         }
 
         private void UpdateRollOutputValues()
         {
-            if (_rollInputSignal != null)
+            if (_rollInputSignal == null) return;
+
+            // Editor override: piecewise_resolver pair. Override path uses the
+            // user's input (no -15° hack); per-channel ZeroTrim is the
+            // editor-supported way to compensate for the gauge's natural
+            // zero offset.
+            if (_rollTransform != null
+                && _rollSinChannel != null
+                && _rollCosChannel != null
+                && _rollSinOutputSignal != null
+                && _rollCosOutputSignal != null)
             {
-                var rollInputDegrees = _rollInputSignal.State - 15;
-                //HACK: compensating for lack of ability to calibrate devices in software right now, so hard-coding this offset for Dave R. instrument
+                var t = _rollTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    _rollInputSignal.State, t.Breakpoints, t.PeakVolts.Value);
+                _rollSinOutputSignal.State = _rollSinChannel.ApplyTrim(sinCos[0], _rollSinOutputSignal.MinValue, _rollSinOutputSignal.MaxValue);
+                _rollCosOutputSignal.State = _rollCosChannel.ApplyTrim(sinCos[1], _rollCosOutputSignal.MinValue, _rollCosOutputSignal.MaxValue);
+                return;
+            }
 
+            // Hardcoded fallback — preserves the -15° offset for Dave R.
+            var rollInputDegrees = _rollInputSignal.State - 15;
+            //HACK: compensating for lack of ability to calibrate devices in software right now, so hard-coding this offset for Dave R. instrument
 
-                var rollSinOutputValue = 10.0000 * Math.Sin(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
-                var rollCosOutputValue = 10.0000 * Math.Cos(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
+            var rollSinOutputValue = 10.0000 * Math.Sin(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
+            var rollCosOutputValue = 10.0000 * Math.Cos(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
 
-                if (_rollSinOutputSignal != null)
-                {
-                    if (rollSinOutputValue < -10)
-                    {
-                        rollSinOutputValue = -10;
-                    }
-                    else if (rollSinOutputValue > 10)
-                    {
-                        rollSinOutputValue = 10;
-                    }
+            if (_rollSinOutputSignal != null)
+            {
+                if (rollSinOutputValue < -10) rollSinOutputValue = -10;
+                else if (rollSinOutputValue > 10) rollSinOutputValue = 10;
+                _rollSinOutputSignal.State = rollSinOutputValue;
+            }
 
-                    _rollSinOutputSignal.State = rollSinOutputValue;
-                }
-
-                if (_rollCosOutputSignal != null)
-                {
-                    if (rollCosOutputValue < -10)
-                    {
-                        rollCosOutputValue = -10;
-                    }
-                    else if (rollCosOutputValue > 10)
-                    {
-                        rollCosOutputValue = 10;
-                    }
-
-                    _rollCosOutputSignal.State = rollCosOutputValue;
-                }
+            if (_rollCosOutputSignal != null)
+            {
+                if (rollCosOutputValue < -10) rollCosOutputValue = -10;
+                else if (rollCosOutputValue > 10) rollCosOutputValue = 10;
+                _rollCosOutputSignal.State = rollCosOutputValue;
             }
         }
 
         private void UpdateVerticalCommandBarOutputValues()
         {
-            if (_verticalCommandBarInputSignal != null)
+            if (_verticalCommandBarInputSignal == null) return;
+            if (_verticalCommandBarOutputSignal == null) return;
+
+            // Show/hide gating preserved verbatim.
+            if (!_showCommandBarsInputSignal.State)
             {
-                var percentDeflection = _verticalCommandBarInputSignal.State;
-
-                var outputValue = _showCommandBarsInputSignal.State ? 4 * percentDeflection : 10;
-
-                if (_verticalCommandBarOutputSignal != null)
-                {
-                    if (outputValue < -10)
-                    {
-                        outputValue = -10;
-                    }
-                    else if (outputValue > 10)
-                    {
-                        outputValue = 10;
-                    }
-
-                    _verticalCommandBarOutputSignal.State = outputValue;
-                }
+                _verticalCommandBarOutputSignal.State = 10;
+                return;
             }
-        }
 
-        private void verticalCommandBar_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
-        {
-            UpdateVerticalCommandBarOutputValues();
+            var percentDeflection = _verticalCommandBarInputSignal.State;
+
+            if (_verticalCommandBarChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _verticalCommandBarChannel.Transform.Breakpoints);
+                _verticalCommandBarOutputSignal.State = _verticalCommandBarChannel.ApplyTrim(v, _verticalCommandBarOutputSignal.MinValue, _verticalCommandBarOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — input × 4.
+            var outputValue = 4 * percentDeflection;
+            if (outputValue < -10) outputValue = -10;
+            else if (outputValue > 10) outputValue = 10;
+            _verticalCommandBarOutputSignal.State = outputValue;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/AMI/AMI9002780-02HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/AMI/AMI9002780-02HardwareSupportModuleConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.AMI
+{
+    // Per-gauge calibration config for AMI 9002780-02 (F-16 Primary ADI,
+    // smaller variant with single-channel pitch). 9 calibratable channels:
+    //
+    //   - Pitch                     (piecewise — single channel, linear)
+    //   - Roll SIN/COS pair         (piecewise_resolver, identity ±180°)
+    //   - 4 digital flags           (digital_invert × 4)
+    //   - Horizontal command bar    (piecewise; show/hide gating stays in C#)
+    //   - Vertical command bar      (piecewise; show/hide gating stays in C#)
+    //   - Rate of turn              (piecewise, ±100% × 10 V)
+    [Serializable]
+    [XmlRoot(nameof(AMI900278002HardwareSupportModule))]
+    public class AMI900278002HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static AMI900278002HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<AMI900278002HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Astronautics/Astronautics12871HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Astronautics/Astronautics12871HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Astronautics
 {
     //Astronautics 12871 F-16 Primary ADI
     public class Astronautics12871HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Astronautics12871HardwareSupportModule));
         private const float GLIDESLOPE_DEVIATION_LIMIT_DEGREES = 1.0F;
         private const float LOCALIZER_DEVIATION_LIMIT_DEGREES = 5.0F;
 
@@ -19,7 +23,6 @@ namespace SimLinkup.HardwareSupport.Astronautics
 
         private DigitalSignal _auxFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _auxFlagInputSignalChangedEventHandler;
-
         private DigitalSignal _auxFlagOutputSignal;
         private DigitalSignal _gsFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _gsFlagInputSignalChangedEventHandler;
@@ -30,7 +33,6 @@ namespace SimLinkup.HardwareSupport.Astronautics
         private AnalogSignal _inclinometerInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _inclinometerInputSignalChangedEventHandler;
         private AnalogSignal _inclinometerOutputSignal;
-
         private bool _isDisposed;
         private DigitalSignal _locFlagInputSignal;
         private DigitalSignal.SignalChangedEventHandler _locFlagInputSignalChangedEventHandler;
@@ -41,8 +43,6 @@ namespace SimLinkup.HardwareSupport.Astronautics
         private AnalogSignal _pitchCosOutputSignal;
         private AnalogSignal _pitchInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _pitchInputSignalChangedEventHandler;
-
-
         private AnalogSignal _pitchSinOutputSignal;
         private AnalogSignal _rateOfTurnInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _rateOfTurnInputSignalChangedEventHandler;
@@ -57,12 +57,160 @@ namespace SimLinkup.HardwareSupport.Astronautics
         private AnalogSignal.AnalogSignalChangedEventHandler _verticalCommandBarInputSignalChangedEventHandler;
         private AnalogSignal _verticalCommandBarOutputSignal;
 
-        private Astronautics12871HardwareSupportModule()
+        // Editor-authored calibration. Each output channel can be overridden
+        // independently — when an override is present, that channel uses
+        // the appropriate Evaluate* helper + ApplyTrim. When absent, the
+        // legacy hardcoded math runs verbatim.
+        private Astronautics12871HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _pitchTransform;
+        private GaugeChannelConfig _pitchSinChannel;
+        private GaugeChannelConfig _pitchCosChannel;
+        private GaugeTransformConfig _rollTransform;
+        private GaugeChannelConfig _rollSinChannel;
+        private GaugeChannelConfig _rollCosChannel;
+        private GaugeChannelConfig _offFlagChannel;
+        private GaugeChannelConfig _gsFlagChannel;
+        private GaugeChannelConfig _locFlagChannel;
+        private GaugeChannelConfig _auxFlagChannel;
+        private GaugeChannelConfig _horizontalCommandBarChannel;
+        private GaugeChannelConfig _verticalCommandBarChannel;
+        private GaugeChannelConfig _inclinometerChannel;
+        private GaugeChannelConfig _rateOfTurnChannel;
+
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Astronautics12871HardwareSupportModule(Astronautics12871HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "12871_Pitch_SIN_To_Instrument",
+                "12871_Pitch_COS_To_Instrument",
+                out _pitchTransform, out _pitchSinChannel, out _pitchCosChannel);
+            ResolvePiecewiseResolverPair(config,
+                "12871_Roll_SIN_To_Instrument",
+                "12871_Roll_COS_To_Instrument",
+                out _rollTransform, out _rollSinChannel, out _rollCosChannel);
+            _offFlagChannel = ResolveDigitalInvertChannel(config, "12871_OFF_Flag_To_Instrument");
+            _gsFlagChannel  = ResolveDigitalInvertChannel(config, "12871_GS_Flag_To_Instrument");
+            _locFlagChannel = ResolveDigitalInvertChannel(config, "12871_LOC_Flag_To_Instrument");
+            _auxFlagChannel = ResolveDigitalInvertChannel(config, "12871_AUX_Flag_To_Instrument");
+            _horizontalCommandBarChannel = ResolvePiecewiseChannel(config, "12871_Horizontal_Command_Bar_To_Instrument");
+            _verticalCommandBarChannel   = ResolvePiecewiseChannel(config, "12871_Vertical_Command_Bar_To_Instrument");
+            _inclinometerChannel = ResolvePiecewiseChannel(config, "12871_Inclinometer_To_Instrument");
+            _rateOfTurnChannel   = ResolvePiecewiseChannel(config, "12871_Rate_Of_Turn_To_Instrument");
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private static GaugeChannelConfig ResolveDigitalInvertChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "digital_invert"
+                && ch.Invert.HasValue)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Astronautics12871HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateAUXFlagOutputValue();
+                UpdateGSFlagOutputValue();
+                UpdateLOCFlagOutputValue();
+                UpdateOFFFlagOutputValue();
+                UpdateHorizontalCommandBarOutputValues();
+                UpdateInclinometerOutputValues();
+                UpdatePitchOutputValues();
+                UpdateRateOfTurnOutputValues();
+                UpdateRollOutputValues();
+                UpdateVerticalCommandBarOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[]
@@ -103,12 +251,23 @@ namespace SimLinkup.HardwareSupport.Astronautics
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Astronautics12871HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Astronautics12871HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Astronautics12871HardwareSupportModule.config");
+                hsmConfig = Astronautics12871HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Astronautics12871HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -578,6 +737,12 @@ namespace SimLinkup.HardwareSupport.Astronautics
                 State = 0.00, //volts;
                 IsVoltage = true,
                 IsSine = true,
+                // NOTE: original C# declared MinValue/MaxValue as ±1 (not ±10)
+                // here, while the matching ROLL COS signal declares ±10. The
+                // ApplyTrim helper now clamps overrides to whichever bounds
+                // are declared, so preserving the original ±1 keeps existing
+                // behavior consistent. If a spec sheet later confirms this
+                // was a typo, change to ±10.
                 MinValue = -1,
                 MaxValue = 1
             };
@@ -651,6 +816,11 @@ namespace SimLinkup.HardwareSupport.Astronautics
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -693,50 +863,17 @@ namespace SimLinkup.HardwareSupport.Astronautics
 
         private void RegisterForInputEvents()
         {
-            if (_auxFlagInputSignal != null)
-            {
-                _auxFlagInputSignal.SignalChanged += _auxFlagInputSignalChangedEventHandler;
-            }
-            if (_gsFlagInputSignal != null)
-            {
-                _gsFlagInputSignal.SignalChanged += _gsFlagInputSignalChangedEventHandler;
-            }
-            if (_locFlagInputSignal != null)
-            {
-                _locFlagInputSignal.SignalChanged += _locFlagInputSignalChangedEventHandler;
-            }
-            if (_offFlagInputSignal != null)
-            {
-                _offFlagInputSignal.SignalChanged += _offFlagInputSignalChangedEventHandler;
-            }
-            if (_pitchInputSignal != null)
-            {
-                _pitchInputSignal.SignalChanged += _pitchInputSignalChangedEventHandler;
-            }
-            if (_rollInputSignal != null)
-            {
-                _rollInputSignal.SignalChanged += _rollInputSignalChangedEventHandler;
-            }
-            if (_horizontalCommandBarInputSignal != null)
-            {
-                _horizontalCommandBarInputSignal.SignalChanged += _horizontalCommandBarInputSignalChangedEventHandler;
-            }
-            if (_verticalCommandBarInputSignal != null)
-            {
-                _verticalCommandBarInputSignal.SignalChanged += _verticalCommandBarInputSignalChangedEventHandler;
-            }
-            if (_rateOfTurnInputSignal != null)
-            {
-                _rateOfTurnInputSignal.SignalChanged += _rateOfTurnInputSignalChangedEventHandler;
-            }
-            if (_inclinometerInputSignal != null)
-            {
-                _inclinometerInputSignal.SignalChanged += _inclinometerInputSignalChangedEventHandler;
-            }
-            if (_showCommandBarsInputSignal != null)
-            {
-                _showCommandBarsInputSignal.SignalChanged += _showCommandBarsInputSignalChangedEventHandler;
-            }
+            if (_auxFlagInputSignal != null) { _auxFlagInputSignal.SignalChanged += _auxFlagInputSignalChangedEventHandler; }
+            if (_gsFlagInputSignal != null) { _gsFlagInputSignal.SignalChanged += _gsFlagInputSignalChangedEventHandler; }
+            if (_locFlagInputSignal != null) { _locFlagInputSignal.SignalChanged += _locFlagInputSignalChangedEventHandler; }
+            if (_offFlagInputSignal != null) { _offFlagInputSignal.SignalChanged += _offFlagInputSignalChangedEventHandler; }
+            if (_pitchInputSignal != null) { _pitchInputSignal.SignalChanged += _pitchInputSignalChangedEventHandler; }
+            if (_rollInputSignal != null) { _rollInputSignal.SignalChanged += _rollInputSignalChangedEventHandler; }
+            if (_horizontalCommandBarInputSignal != null) { _horizontalCommandBarInputSignal.SignalChanged += _horizontalCommandBarInputSignalChangedEventHandler; }
+            if (_verticalCommandBarInputSignal != null) { _verticalCommandBarInputSignal.SignalChanged += _verticalCommandBarInputSignalChangedEventHandler; }
+            if (_rateOfTurnInputSignal != null) { _rateOfTurnInputSignal.SignalChanged += _rateOfTurnInputSignalChangedEventHandler; }
+            if (_inclinometerInputSignal != null) { _inclinometerInputSignal.SignalChanged += _inclinometerInputSignalChangedEventHandler; }
+            if (_showCommandBarsInputSignal != null) { _showCommandBarsInputSignal.SignalChanged += _showCommandBarsInputSignalChangedEventHandler; }
         }
 
         private void roll_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
@@ -750,160 +887,106 @@ namespace SimLinkup.HardwareSupport.Astronautics
             UpdateVerticalCommandBarOutputValues();
         }
 
+        private void verticalCommandBar_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
+        {
+            UpdateVerticalCommandBarOutputValues();
+        }
+
         private void UnregisterForInputEvents()
         {
-            if (_auxFlagInputSignalChangedEventHandler != null && _auxFlagInputSignal != null)
-            {
-                try
-                {
-                    _auxFlagInputSignal.SignalChanged -= _auxFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_gsFlagInputSignalChangedEventHandler != null && _gsFlagInputSignal != null)
-            {
-                try
-                {
-                    _gsFlagInputSignal.SignalChanged -= _gsFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_locFlagInputSignalChangedEventHandler != null && _locFlagInputSignal != null)
-            {
-                try
-                {
-                    _locFlagInputSignal.SignalChanged -= _locFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_offFlagInputSignalChangedEventHandler != null && _offFlagInputSignal != null)
-            {
-                try
-                {
-                    _offFlagInputSignal.SignalChanged -= _offFlagInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_pitchInputSignalChangedEventHandler != null && _pitchInputSignal != null)
-            {
-                try
-                {
-                    _pitchInputSignal.SignalChanged -= _pitchInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_rollInputSignalChangedEventHandler != null && _rollInputSignal != null)
-            {
-                try
-                {
-                    _rollInputSignal.SignalChanged -= _rollInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_horizontalCommandBarInputSignalChangedEventHandler != null && _horizontalCommandBarInputSignal != null)
-            {
-                try
-                {
-                    _horizontalCommandBarInputSignal.SignalChanged -=
-                        _horizontalCommandBarInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_verticalCommandBarInputSignalChangedEventHandler != null && _verticalCommandBarInputSignal != null)
-            {
-                try
-                {
-                    _verticalCommandBarInputSignal.SignalChanged -= _verticalCommandBarInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_rateOfTurnInputSignalChangedEventHandler != null && _rateOfTurnInputSignal != null)
-            {
-                try
-                {
-                    _rateOfTurnInputSignal.SignalChanged -= _rateOfTurnInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_inclinometerInputSignalChangedEventHandler != null && _inclinometerInputSignal != null)
-            {
-                try
-                {
-                    _inclinometerInputSignal.SignalChanged -= _inclinometerInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
-            if (_showCommandBarsInputSignalChangedEventHandler != null && _showCommandBarsInputSignal != null)
-            {
-                try
-                {
-                    _showCommandBarsInputSignal.SignalChanged -= _showCommandBarsInputSignalChangedEventHandler;
-                }
-                catch (RemotingException)
-                {
-                }
-            }
+            try { if (_auxFlagInputSignal != null) _auxFlagInputSignal.SignalChanged -= _auxFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_gsFlagInputSignal != null) _gsFlagInputSignal.SignalChanged -= _gsFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_locFlagInputSignal != null) _locFlagInputSignal.SignalChanged -= _locFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_offFlagInputSignal != null) _offFlagInputSignal.SignalChanged -= _offFlagInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_pitchInputSignal != null) _pitchInputSignal.SignalChanged -= _pitchInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_rollInputSignal != null) _rollInputSignal.SignalChanged -= _rollInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_horizontalCommandBarInputSignal != null) _horizontalCommandBarInputSignal.SignalChanged -= _horizontalCommandBarInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_verticalCommandBarInputSignal != null) _verticalCommandBarInputSignal.SignalChanged -= _verticalCommandBarInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_rateOfTurnInputSignal != null) _rateOfTurnInputSignal.SignalChanged -= _rateOfTurnInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_inclinometerInputSignal != null) _inclinometerInputSignal.SignalChanged -= _inclinometerInputSignalChangedEventHandler; } catch (RemotingException) { }
+            try { if (_showCommandBarsInputSignal != null) _showCommandBarsInputSignal.SignalChanged -= _showCommandBarsInputSignalChangedEventHandler; } catch (RemotingException) { }
+        }
+
+        private static bool ApplyDigitalInvert(GaugeChannelConfig ch, bool input)
+        {
+            // ch.Invert.HasValue is guaranteed by ResolveDigitalInvertChannel.
+            return ch.Invert.Value ? !input : input;
         }
 
         private void UpdateAUXFlagOutputValue()
         {
+            if (_auxFlagOutputSignal == null) return;
+            if (_auxFlagChannel != null) { _auxFlagOutputSignal.State = ApplyDigitalInvert(_auxFlagChannel, _auxFlagInputSignal.State); return; }
             _auxFlagOutputSignal.State = !_auxFlagInputSignal.State;
         }
 
         private void UpdateGSFlagOutputValue()
         {
+            if (_gsFlagOutputSignal == null) return;
+            if (_gsFlagChannel != null) { _gsFlagOutputSignal.State = ApplyDigitalInvert(_gsFlagChannel, _gsFlagInputSignal.State); return; }
             _gsFlagOutputSignal.State = !_gsFlagInputSignal.State;
+        }
+
+        private void UpdateLOCFlagOutputValue()
+        {
+            if (_locFlagOutputSignal == null) return;
+            if (_locFlagChannel != null) { _locFlagOutputSignal.State = ApplyDigitalInvert(_locFlagChannel, _locFlagInputSignal.State); return; }
+            _locFlagOutputSignal.State = !_locFlagInputSignal.State;
+        }
+
+        private void UpdateOFFFlagOutputValue()
+        {
+            if (_offFlagOutputSignal == null) return;
+            if (_offFlagChannel != null) { _offFlagOutputSignal.State = ApplyDigitalInvert(_offFlagChannel, _offFlagInputSignal.State); return; }
+            _offFlagOutputSignal.State = !_offFlagInputSignal.State;
         }
 
         private void UpdateHorizontalCommandBarOutputValues()
         {
             if (_horizontalCommandBarInputSignal == null) return;
+            if (_horizontalCommandBarOutputSignal == null) return;
+
+            // Show/hide gating stays in C# regardless of override status —
+            // when bars are hidden the gauge expects +10 V (parked off-screen).
+            if (!_showCommandBarsInputSignal.State)
+            {
+                _horizontalCommandBarOutputSignal.State = 10;
+                return;
+            }
+
             var percentDeflection = _horizontalCommandBarInputSignal.State;
 
-            var outputValue = _showCommandBarsInputSignal.State ? percentDeflection * 2.25f : 10;
-
-            if (_horizontalCommandBarOutputSignal == null) return;
-            if (outputValue < -10)
+            if (_horizontalCommandBarChannel != null)
             {
-                outputValue = -10;
-            }
-            else if (outputValue > 10)
-            {
-                outputValue = 10;
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _horizontalCommandBarChannel.Transform.Breakpoints);
+                _horizontalCommandBarOutputSignal.State = _horizontalCommandBarChannel.ApplyTrim(v, _horizontalCommandBarOutputSignal.MinValue, _horizontalCommandBarOutputSignal.MaxValue);
+                return;
             }
 
+            // Hardcoded fallback — input × 2.25.
+            var outputValue = percentDeflection * 2.25f;
+            if (outputValue < -10) outputValue = -10;
+            else if (outputValue > 10) outputValue = 10;
             _horizontalCommandBarOutputSignal.State = outputValue;
         }
-
 
         private void UpdateInclinometerOutputValues()
         {
             if (_inclinometerInputSignal == null) return;
+            if (_inclinometerOutputSignal == null) return;
             var percentDeflection = _inclinometerInputSignal.State;
 
-            var outputValue = 10.0000 * percentDeflection;
+            if (_inclinometerChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _inclinometerChannel.Transform.Breakpoints);
+                _inclinometerOutputSignal.State = _inclinometerChannel.ApplyTrim(v, _inclinometerOutputSignal.MinValue, _inclinometerOutputSignal.MaxValue);
+                return;
+            }
 
-            if (_inclinometerOutputSignal == null) return;
+            // Hardcoded fallback — preserves original behavior exactly,
+            // including the `else if (output > 10) output = 0` over-range
+            // case (likely an intentional fail-safe for off-spec input).
+            var outputValue = 10.0000 * percentDeflection;
             if (outputValue < -10)
             {
                 outputValue = -10;
@@ -912,53 +995,44 @@ namespace SimLinkup.HardwareSupport.Astronautics
             {
                 outputValue = 0;
             }
-
             _inclinometerOutputSignal.State = outputValue;
-        }
-
-        private void UpdateLOCFlagOutputValue()
-        {
-            _locFlagOutputSignal.State = !_locFlagInputSignal.State;
-        }
-
-        private void UpdateOFFFlagOutputValue()
-        {
-            _offFlagOutputSignal.State = !_offFlagInputSignal.State;
         }
 
         private void UpdatePitchOutputValues()
         {
-            if (_pitchInputSignal != null)
+            if (_pitchInputSignal == null) return;
+            var pitchInputDegrees = _pitchInputSignal.State;
+
+            // Editor override: piecewise_resolver pair.
+            if (_pitchTransform != null
+                && _pitchSinChannel != null
+                && _pitchCosChannel != null
+                && _pitchSinOutputSignal != null
+                && _pitchCosOutputSignal != null)
             {
-                var pitchInputDegrees = _pitchInputSignal.State;
+                var t = _pitchTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    pitchInputDegrees, t.Breakpoints, t.PeakVolts.Value);
+                _pitchSinOutputSignal.State = _pitchSinChannel.ApplyTrim(sinCos[0], _pitchSinOutputSignal.MinValue, _pitchSinOutputSignal.MaxValue);
+                _pitchCosOutputSignal.State = _pitchCosChannel.ApplyTrim(sinCos[1], _pitchCosOutputSignal.MinValue, _pitchCosOutputSignal.MaxValue);
+                return;
+            }
 
-                var pitchSinOutputValue = 10.0000 * Math.Sin(pitchInputDegrees * Constants.RADIANS_PER_DEGREE);
-                var pitchCosOutputValue = 10.0000 * Math.Cos(pitchInputDegrees * Constants.RADIANS_PER_DEGREE);
+            // Hardcoded fallback — straight 10·sin/cos(input°).
+            var pitchSinOutputValue = 10.0000 * Math.Sin(pitchInputDegrees * Constants.RADIANS_PER_DEGREE);
+            var pitchCosOutputValue = 10.0000 * Math.Cos(pitchInputDegrees * Constants.RADIANS_PER_DEGREE);
 
-                if (_pitchSinOutputSignal != null)
-                {
-                    if (pitchSinOutputValue < -10)
-                    {
-                        pitchSinOutputValue = -10;
-                    }
-                    else if (pitchSinOutputValue > 10)
-                    {
-                        pitchSinOutputValue = 10;
-                    }
+            if (_pitchSinOutputSignal != null)
+            {
+                if (pitchSinOutputValue < -10) pitchSinOutputValue = -10;
+                else if (pitchSinOutputValue > 10) pitchSinOutputValue = 10;
+                _pitchSinOutputSignal.State = pitchSinOutputValue;
+            }
 
-                    _pitchSinOutputSignal.State = pitchSinOutputValue;
-                }
-
-                if (_pitchCosOutputSignal == null) return;
-                if (pitchCosOutputValue < -10)
-                {
-                    pitchCosOutputValue = -10;
-                }
-                else if (pitchCosOutputValue > 10)
-                {
-                    pitchCosOutputValue = 10;
-                }
-
+            if (_pitchCosOutputSignal != null)
+            {
+                if (pitchCosOutputValue < -10) pitchCosOutputValue = -10;
+                else if (pitchCosOutputValue > 10) pitchCosOutputValue = 10;
                 _pitchCosOutputSignal.State = pitchCosOutputValue;
             }
         }
@@ -966,11 +1040,18 @@ namespace SimLinkup.HardwareSupport.Astronautics
         private void UpdateRateOfTurnOutputValues()
         {
             if (_rateOfTurnInputSignal == null) return;
+            if (_rateOfTurnOutputSignal == null) return;
             var percentDeflection = _rateOfTurnInputSignal.State;
 
-            var outputValue = 10.0000 * percentDeflection;
+            if (_rateOfTurnChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _rateOfTurnChannel.Transform.Breakpoints);
+                _rateOfTurnOutputSignal.State = _rateOfTurnChannel.ApplyTrim(v, _rateOfTurnOutputSignal.MinValue, _rateOfTurnOutputSignal.MaxValue);
+                return;
+            }
 
-            if (_rateOfTurnOutputSignal == null) return;
+            // Hardcoded fallback — preserves original behavior verbatim.
+            var outputValue = 10.0000 * percentDeflection;
             if (outputValue < -10)
             {
                 outputValue = -10;
@@ -979,7 +1060,6 @@ namespace SimLinkup.HardwareSupport.Astronautics
             {
                 outputValue = 0;
             }
-
             _rateOfTurnOutputSignal.State = outputValue;
         }
 
@@ -988,61 +1068,69 @@ namespace SimLinkup.HardwareSupport.Astronautics
             if (_rollInputSignal == null) return;
             var rollInputDegrees = _rollInputSignal.State;
 
+            // Editor override: piecewise_resolver pair.
+            if (_rollTransform != null
+                && _rollSinChannel != null
+                && _rollCosChannel != null
+                && _rollSinOutputSignal != null
+                && _rollCosOutputSignal != null)
+            {
+                var t = _rollTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    rollInputDegrees, t.Breakpoints, t.PeakVolts.Value);
+                _rollSinOutputSignal.State = _rollSinChannel.ApplyTrim(sinCos[0], _rollSinOutputSignal.MinValue, _rollSinOutputSignal.MaxValue);
+                _rollCosOutputSignal.State = _rollCosChannel.ApplyTrim(sinCos[1], _rollCosOutputSignal.MinValue, _rollCosOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — straight 10·sin/cos(input°). Note: the
+            // original C# clamp on roll SIN is at ±10 even though the SIN
+            // signal's MinValue/MaxValue are declared at ±1. Preserves
+            // legacy behavior verbatim.
             var rollSinOutputValue = 10.0000 * Math.Sin(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
             var rollCosOutputValue = 10.0000 * Math.Cos(rollInputDegrees * Constants.RADIANS_PER_DEGREE);
 
             if (_rollSinOutputSignal != null)
             {
-                if (rollSinOutputValue < -10)
-                {
-                    rollSinOutputValue = -10;
-                }
-                else if (rollSinOutputValue > 10)
-                {
-                    rollSinOutputValue = 10;
-                }
-
+                if (rollSinOutputValue < -10) rollSinOutputValue = -10;
+                else if (rollSinOutputValue > 10) rollSinOutputValue = 10;
                 _rollSinOutputSignal.State = rollSinOutputValue;
             }
 
-            if (_rollCosOutputSignal == null) return;
-            if (rollCosOutputValue < -10)
+            if (_rollCosOutputSignal != null)
             {
-                rollCosOutputValue = -10;
+                if (rollCosOutputValue < -10) rollCosOutputValue = -10;
+                else if (rollCosOutputValue > 10) rollCosOutputValue = 10;
+                _rollCosOutputSignal.State = rollCosOutputValue;
             }
-            else if (rollCosOutputValue > 10)
-            {
-                rollCosOutputValue = 10;
-            }
-
-            _rollCosOutputSignal.State = rollCosOutputValue;
         }
 
         private void UpdateVerticalCommandBarOutputValues()
         {
-            if (_verticalCommandBarInputSignal != null)
+            if (_verticalCommandBarInputSignal == null) return;
+            if (_verticalCommandBarOutputSignal == null) return;
+
+            // Show/hide gating stays in C# regardless of override status.
+            if (!_showCommandBarsInputSignal.State)
             {
-                var percentDeflection = _verticalCommandBarInputSignal.State;
-
-                var outputValue = _showCommandBarsInputSignal.State ? percentDeflection * 2.25f : 10;
-
-                if (_verticalCommandBarOutputSignal == null) return;
-                if (outputValue < -10)
-                {
-                    outputValue = -10;
-                }
-                else if (outputValue > 10)
-                {
-                    outputValue = 10;
-                }
-
-                _verticalCommandBarOutputSignal.State = outputValue;
+                _verticalCommandBarOutputSignal.State = 10;
+                return;
             }
-        }
 
-        private void verticalCommandBar_InputSignalChanged(object sender, AnalogSignalChangedEventArgs args)
-        {
-            UpdateVerticalCommandBarOutputValues();
+            var percentDeflection = _verticalCommandBarInputSignal.State;
+
+            if (_verticalCommandBarChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(percentDeflection, _verticalCommandBarChannel.Transform.Breakpoints);
+                _verticalCommandBarOutputSignal.State = _verticalCommandBarChannel.ApplyTrim(v, _verticalCommandBarOutputSignal.MinValue, _verticalCommandBarOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — input × 2.25.
+            var outputValue = percentDeflection * 2.25f;
+            if (outputValue < -10) outputValue = -10;
+            else if (outputValue > 10) outputValue = 10;
+            _verticalCommandBarOutputSignal.State = outputValue;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Astronautics/Astronautics12871HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Astronautics/Astronautics12871HardwareSupportModuleConfig.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Astronautics
+{
+    // Per-gauge calibration config for Astronautics 12871 (F-16 Primary
+    // ADI). 10 calibratable channels:
+    //
+    //   - Pitch SIN/COS pair        (piecewise_resolver, identity ±90°)
+    //   - Roll SIN/COS pair         (piecewise_resolver, identity ±180°)
+    //   - 4 digital flags           (digital_invert × 4: OFF, GS, LOC, AUX)
+    //   - Horizontal command bar    (piecewise; show/hide gating stays in C#)
+    //   - Vertical command bar      (piecewise; show/hide gating stays in C#)
+    //   - Inclinometer              (piecewise, ±100% × 10 V)
+    //   - Rate of turn              (piecewise, ±100% × 10 V)
+    [Serializable]
+    [XmlRoot(nameof(Astronautics12871HardwareSupportModule))]
+    public class Astronautics12871HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Astronautics12871HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Astronautics12871HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Gould/GouldHS070D51341HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Gould/GouldHS070D51341HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Gould
 {
     //GOULD F-16 COMPASS
     public class GouldHS070D51341HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(GouldHS070D51341HardwareSupportModule));
         private readonly ICompass _compass = new Compass();
         private AnalogSignal _compassCOSOutputSignal;
         private AnalogSignal _compassInputSignal;
@@ -20,12 +24,94 @@ namespace SimLinkup.HardwareSupport.Gould
 
         private bool _isDisposed;
 
-        private GouldHS070D51341HardwareSupportModule()
+        private GouldHS070D51341HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public GouldHS070D51341HardwareSupportModule(GouldHS070D51341HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "HS070D51341_Compass__SIN_To_Instrument",
+                "HS070D51341_Compass__COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = GouldHS070D51341HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] {_compassInputSignal};
@@ -51,12 +137,23 @@ namespace SimLinkup.HardwareSupport.Gould
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            GouldHS070D51341HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new GouldHS070D51341HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "GouldHS070D51341HardwareSupportModule.config");
+                hsmConfig = GouldHS070D51341HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new GouldHS070D51341HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -164,6 +261,11 @@ namespace SimLinkup.HardwareSupport.Gould
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_compass);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -195,34 +297,35 @@ namespace SimLinkup.HardwareSupport.Gould
         {
             if (_compassInputSignal == null) return;
             var compassInput = Math.Abs(_compassInputSignal.CorrelatedState % 360.000);
+
+            // Editor override: piecewise_resolver pair.
+            if (_resolverTransform != null
+                && _sinChannel != null
+                && _cosChannel != null
+                && _compassSINOutputSignal != null
+                && _compassCOSOutputSignal != null)
+            {
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    compassInput, t.Breakpoints, t.PeakVolts.Value);
+                _compassSINOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _compassSINOutputSignal.MinValue, _compassSINOutputSignal.MaxValue);
+                _compassCOSOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _compassCOSOutputSignal.MinValue, _compassCOSOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — straight 10·sin/cos(input°).
             if (_compassSINOutputSignal != null)
             {
                 var compassSINOutputValue = 10.0000 * Math.Sin(compassInput * Constants.RADIANS_PER_DEGREE);
-
-                if (compassSINOutputValue < -10)
-                {
-                    compassSINOutputValue = -10;
-                }
-                else if (compassSINOutputValue > 10)
-                {
-                    compassSINOutputValue = 10;
-                }
-
+                if (compassSINOutputValue < -10) compassSINOutputValue = -10;
+                else if (compassSINOutputValue > 10) compassSINOutputValue = 10;
                 _compassSINOutputSignal.State = compassSINOutputValue;
             }
 
             if (_compassCOSOutputSignal == null) return;
             var compassCOSOutputValue = 10.0000 * Math.Cos(compassInput * Constants.RADIANS_PER_DEGREE);
-
-            if (compassCOSOutputValue < -10)
-            {
-                compassCOSOutputValue = -10;
-            }
-            else if (compassCOSOutputValue > 10)
-            {
-                compassCOSOutputValue = 10;
-            }
-
+            if (compassCOSOutputValue < -10) compassCOSOutputValue = -10;
+            else if (compassCOSOutputValue > 10) compassCOSOutputValue = 10;
             _compassCOSOutputSignal.State = compassCOSOutputValue;
         }
     }

--- a/src/SimLinkup/HardwareSupport/Gould/GouldHS070D51341HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Gould/GouldHS070D51341HardwareSupportModuleConfig.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Gould
+{
+    // Per-gauge calibration config for Gould HS070D5134-1 (F-16 Standby
+    // Compass). Single piecewise_resolver pair (sin/cos) mapping 0..360°
+    // magnetic heading to a continuous resolver angle. Same gauge family as
+    // Simtek 10-1079.
+    [Serializable]
+    [XmlRoot(nameof(GouldHS070D51341HardwareSupportModule))]
+    public class GouldHS070D51341HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static GouldHS070D51341HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<GouldHS070D51341HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3239HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3239HardwareSupportModule.cs
@@ -1,16 +1,20 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Lilbern
 {
     //Lilbern 3239 F-16A Fuel Flow Indicator
     public class Lilbern3239HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Lilbern3239HardwareSupportModule));
         private readonly IFuelFlow _renderer = new FuelFlow();
 
         private AnalogSignal _fuelFlowInputSignal;
@@ -18,12 +22,75 @@ namespace SimLinkup.HardwareSupport.Lilbern
         private AnalogSignal _fuelFlowOutputSignal;
         private bool _isDisposed;
 
-        private Lilbern3239HardwareSupportModule()
+        private Lilbern3239HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _fuelFlowChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Lilbern3239HardwareSupportModule(Lilbern3239HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _fuelFlowChannel = ResolvePiecewiseChannel(config, "3239_Fuel_Flow_Pounds_Per_Hour_To_Instrument");
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Lilbern3239HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateFuelFlowOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] {_fuelFlowInputSignal};
@@ -49,12 +116,23 @@ namespace SimLinkup.HardwareSupport.Lilbern
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Lilbern3239HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Lilbern3239HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Lilbern3239HardwareSupportModule.config");
+                hsmConfig = Lilbern3239HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Lilbern3239HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -132,6 +210,11 @@ namespace SimLinkup.HardwareSupport.Lilbern
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -166,25 +249,23 @@ namespace SimLinkup.HardwareSupport.Lilbern
 
         private void UpdateFuelFlowOutputValues()
         {
-            if (_fuelFlowInputSignal != null)
+            if (_fuelFlowInputSignal == null) return;
+            if (_fuelFlowOutputSignal == null) return;
+            var fuelFlowInput = _fuelFlowInputSignal.State;
+
+            // Editor override: piecewise channel.
+            if (_fuelFlowChannel != null)
             {
-                var fuelFlowInput = _fuelFlowInputSignal.State;
-
-                var fuelFlowOutputValue = fuelFlowInput <= 0 ? -10.00 : -10.00 + fuelFlowInput / 80000.0000 * 20.0000;
-
-
-                if (_fuelFlowOutputSignal == null) return;
-                if (fuelFlowOutputValue < -10)
-                {
-                    fuelFlowOutputValue = -10;
-                }
-                else if (fuelFlowOutputValue > 10)
-                {
-                    fuelFlowOutputValue = 10;
-                }
-
-                _fuelFlowOutputSignal.State = fuelFlowOutputValue;
+                var v = GaugeTransform.EvaluatePiecewise(fuelFlowInput, _fuelFlowChannel.Transform.Breakpoints);
+                _fuelFlowOutputSignal.State = _fuelFlowChannel.ApplyTrim(v, _fuelFlowOutputSignal.MinValue, _fuelFlowOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — 0..80000 lbs/hr → -10..+10 V linear.
+            var fuelFlowOutputValue = fuelFlowInput <= 0 ? -10.00 : -10.00 + fuelFlowInput / 80000.0000 * 20.0000;
+            if (fuelFlowOutputValue < -10) fuelFlowOutputValue = -10;
+            else if (fuelFlowOutputValue > 10) fuelFlowOutputValue = 10;
+            _fuelFlowOutputSignal.State = fuelFlowOutputValue;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3239HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3239HardwareSupportModuleConfig.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Lilbern
+{
+    // Per-gauge calibration config for Lilbern 3239 (F-16A Fuel Flow
+    // Indicator). Single piecewise channel — linear mapping 0..80000 lbs/hr
+    // to -10..+10 V.
+    [Serializable]
+    [XmlRoot(nameof(Lilbern3239HardwareSupportModule))]
+    public class Lilbern3239HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Lilbern3239HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Lilbern3239HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3321HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3321HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Lilbern
 {
     //Lilbern 3321 F-16 RPM Indicator
     public class Lilbern3321HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Lilbern3321HardwareSupportModule));
         private readonly ITachometer _renderer = new Tachometer();
 
         private bool _isDisposed;
@@ -20,12 +24,94 @@ namespace SimLinkup.HardwareSupport.Lilbern
         private AnalogSignal _rpmSinOutputSignal;
         private AnalogSignal _rpmCosOutputSignal;
 
-        private Lilbern3321HardwareSupportModule()
+        private Lilbern3321HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Lilbern3321HardwareSupportModule(Lilbern3321HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "3321_RPM_SIN_To_Instrument",
+                "3321_RPM_COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Lilbern3321HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] { _rpmInputSignal };
@@ -51,12 +137,23 @@ namespace SimLinkup.HardwareSupport.Lilbern
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Lilbern3321HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Lilbern3321HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Lilbern3321HardwareSupportModule.config");
+                hsmConfig = Lilbern3321HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Lilbern3321HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -156,6 +253,11 @@ namespace SimLinkup.HardwareSupport.Lilbern
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -190,65 +292,50 @@ namespace SimLinkup.HardwareSupport.Lilbern
 
         private void UpdateOutputValues()
         {
-            if (_rpmInputSignal != null)
+            if (_rpmInputSignal == null) return;
+            var rpmInput = _rpmInputSignal.State;
+            if (_rpmSinOutputSignal == null || _rpmCosOutputSignal == null) return;
+
+            // Editor override: piecewise_resolver pair.
+            if (_resolverTransform != null && _sinChannel != null && _cosChannel != null)
             {
-                /*
-                 * This code is donated from another module that computed +/-10V linear output values directly.
-                 * Adaptation below converts +/-10V values to percentage of full-scale range, then converts
-                 * that to an angle, and then back to the corresponding SIN/COS +/-10V output signal pair.
-                 */
-                var rpmInput = _rpmInputSignal.State;
-                if (_rpmSinOutputSignal != null && _rpmCosOutputSignal != null)
-                {
-                    var degrees = 0.00;
-                    var sixtyRpmDegrees = 90;
-                    var oneHundredTenRpmDegrees = 330;
-                    if (rpmInput < 60)
-                    {
-                        degrees = (rpmInput / 60.00) * sixtyRpmDegrees;
-                    }
-                    else
-                    {
-                        degrees =
-                            (rpmInput - 60.00) //how far past 60 degrees are we
-                                /  //as a fraction of
-                            (110 - 60) //the width of the range in RPM from 60-110 RPM on the dial face
-                            * (oneHundredTenRpmDegrees - sixtyRpmDegrees) //times the distance in degrees represented by that span
-                            + sixtyRpmDegrees; // plus the offset for the sixty-RPM mark in degrees
-                    }
-
-                    var sinRaw = Math.Sin(degrees * Constants.RADIANS_PER_DEGREE);
-                    var cosRaw = Math.Cos(degrees * Constants.RADIANS_PER_DEGREE);
-                    var sinVoltage = sinRaw * 10.00;
-                    var cosVoltage = cosRaw * 10.00;
-
-                    if (_rpmSinOutputSignal != null)
-                    {
-                        if (sinVoltage > 10.00)
-                        {
-                            sinVoltage = 10.00;
-                        }
-                        else if (sinVoltage < -10.00)
-                        {
-                            sinVoltage = -10.00;
-                        }
-                        _rpmSinOutputSignal.State = sinVoltage;
-                    }
-
-                    if (_rpmCosOutputSignal != null)
-                    {
-                        if (cosVoltage > 10.00)
-                        {
-                            cosVoltage = 10.00;
-                        }
-                        else if (cosVoltage < -10.00)
-                        {
-                            cosVoltage = -10.00;
-                        }
-                        _rpmCosOutputSignal.State = cosVoltage;
-                    }
-               }
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    rpmInput, t.Breakpoints, t.PeakVolts.Value);
+                _rpmSinOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _rpmSinOutputSignal.MinValue, _rpmSinOutputSignal.MaxValue);
+                _rpmCosOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _rpmCosOutputSignal.MinValue, _rpmCosOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — input → angle via two-segment piecewise,
+            // then sin/cos × 10 V.
+            var degrees = 0.00;
+            var sixtyRpmDegrees = 90;
+            var oneHundredTenRpmDegrees = 330;
+            if (rpmInput < 60)
+            {
+                degrees = (rpmInput / 60.00) * sixtyRpmDegrees;
+            }
+            else
+            {
+                degrees =
+                    (rpmInput - 60.00)
+                        /
+                    (110 - 60)
+                    * (oneHundredTenRpmDegrees - sixtyRpmDegrees)
+                    + sixtyRpmDegrees;
+            }
+
+            var sinVoltage = Math.Sin(degrees * Constants.RADIANS_PER_DEGREE) * 10.00;
+            var cosVoltage = Math.Cos(degrees * Constants.RADIANS_PER_DEGREE) * 10.00;
+
+            if (sinVoltage > 10.00) sinVoltage = 10.00;
+            else if (sinVoltage < -10.00) sinVoltage = -10.00;
+            _rpmSinOutputSignal.State = sinVoltage;
+
+            if (cosVoltage > 10.00) cosVoltage = 10.00;
+            else if (cosVoltage < -10.00) cosVoltage = -10.00;
+            _rpmCosOutputSignal.State = cosVoltage;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3321HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Lilbern/Lilbern3321HardwareSupportModuleConfig.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Lilbern
+{
+    // Per-gauge calibration config for Lilbern 3321 (F-16 Tachometer/RPM
+    // Indicator). Single piecewise_resolver pair (sin/cos) — input %RPM
+    // maps to dial pointer angle via two linear segments (0..60% → 0..90°,
+    // 60..110% → 90..330°), then sin/cos × 10 V.
+    [Serializable]
+    [XmlRoot(nameof(Lilbern3321HardwareSupportModule))]
+    public class Lilbern3321HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Lilbern3321HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Lilbern3321HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19562HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19562HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Malwin
 {
-    //Malwin 1956-2 F-16 FTIT Indicator 
+    //Malwin 1956-2 F-16 FTIT Indicator
     public class Malwin19562HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Malwin19562HardwareSupportModule));
         private readonly IFanTurbineInletTemperature _renderer = new FanTurbineInletTemperature();
 
         private AnalogSignal _ftitInputSignal;
@@ -21,12 +25,94 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private bool _isDisposed;
 
-        private Malwin19562HardwareSupportModule()
+        private Malwin19562HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Malwin19562HardwareSupportModule(Malwin19562HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "19562_FTIT_SIN_To_Instrument",
+                "19562_FTIT_COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Malwin19562HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] { _ftitInputSignal };
@@ -52,12 +138,23 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Malwin19562HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Malwin19562HardwareSupportModule ()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Malwin19562HardwareSupportModule.config");
+                hsmConfig = Malwin19562HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Malwin19562HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -158,6 +255,11 @@ namespace SimLinkup.HardwareSupport.Malwin
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -192,61 +294,54 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private void UpdateOutputValues()
         {
-            if (_ftitInputSignal != null)
+            if (_ftitInputSignal == null) return;
+            if (_ftitSinOutputSignal == null || _ftitCosOutputSignal == null) return;
+            var ftitInput = _ftitInputSignal.State;
+            if (ftitInput < 0.00) ftitInput = 0;
+            else if (ftitInput > 1200.00) ftitInput = 1200.00;
+
+            // Editor override: piecewise_resolver pair.
+            if (_resolverTransform != null && _sinChannel != null && _cosChannel != null)
             {
-                var ftitInput = _ftitInputSignal.State;
-                double ftitOutputDegrees = 0;
-                if (ftitInput < 0.00)
-                {
-                    ftitInput = 0;
-                }
-                else if (ftitInput > 1200.00)
-                {
-                    ftitInput = 1200.00;
-                }
-
-                if (_ftitSinOutputSignal != null && _ftitCosOutputSignal != null)
-                {
-                    if (ftitInput <= 200)
-                    {
-                        ftitOutputDegrees = 0;
-                    }
-                    else if (ftitInput >= 200 && ftitInput < 700)
-                    {
-                        ftitOutputDegrees = 20.00 * ((ftitInput - 200.00) / 100.00); // 20 degrees of angle per 100 Degrees C
-                    }
-                    else if (ftitInput >= 700 && ftitInput < 1000)
-                    {
-                        ftitOutputDegrees = (60.00 * ((ftitInput - 700.00) / 100.00)) + 100.00; // 60 degrees of angle per 100 Degrees C, starting at 100 degrees of angle
-                    }
-                    else if (ftitInput >= 1000 && ftitInput <= 1200)
-                    {
-                        ftitOutputDegrees = (20.00 * ((ftitInput - 1000.00) / 100.00)) + 280; // 20 degrees of angle per 100 Degrees C, starting at 280 degrees of angle
-                    }
-
-                    var ftitOutputSinVoltage = Math.Sin(ftitOutputDegrees * Constants.RADIANS_PER_DEGREE);
-                    if (ftitOutputSinVoltage < -10)
-                    {
-                        ftitOutputSinVoltage = -10;
-                    }
-                    else if (ftitOutputSinVoltage > 10)
-                    {
-                        ftitOutputSinVoltage = 10;
-                    }
-                    _ftitSinOutputSignal.State = ftitOutputSinVoltage;
-
-                    var ftitOutputCosVoltage = Math.Cos(ftitOutputDegrees * Constants.RADIANS_PER_DEGREE);
-                    if (ftitOutputCosVoltage < -10)
-                    {
-                        ftitOutputCosVoltage = -10;
-                    }
-                    else if (ftitOutputCosVoltage > 10)
-                    {
-                        ftitOutputCosVoltage = 10;
-                    }
-                    _ftitCosOutputSignal.State = ftitOutputCosVoltage;
-                }
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    ftitInput, t.Breakpoints, t.PeakVolts.Value);
+                _ftitSinOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _ftitSinOutputSignal.MinValue, _ftitSinOutputSignal.MaxValue);
+                _ftitCosOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _ftitCosOutputSignal.MinValue, _ftitCosOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — input → angle via 4-segment piecewise,
+            // then sin/cos × 10 V. NOTE: the original C# was missing the
+            // ×10 multiplier so legacy installs got ±1 V output. The
+            // multiplier is now applied here to fix the fallback path.
+            double ftitOutputDegrees = 0;
+            if (ftitInput <= 200)
+            {
+                ftitOutputDegrees = 0;
+            }
+            else if (ftitInput >= 200 && ftitInput < 700)
+            {
+                ftitOutputDegrees = 20.00 * ((ftitInput - 200.00) / 100.00);
+            }
+            else if (ftitInput >= 700 && ftitInput < 1000)
+            {
+                ftitOutputDegrees = (60.00 * ((ftitInput - 700.00) / 100.00)) + 100.00;
+            }
+            else if (ftitInput >= 1000 && ftitInput <= 1200)
+            {
+                ftitOutputDegrees = (20.00 * ((ftitInput - 1000.00) / 100.00)) + 280;
+            }
+
+            var ftitOutputSinVoltage = 10.00 * Math.Sin(ftitOutputDegrees * Constants.RADIANS_PER_DEGREE);
+            if (ftitOutputSinVoltage < -10) ftitOutputSinVoltage = -10;
+            else if (ftitOutputSinVoltage > 10) ftitOutputSinVoltage = 10;
+            _ftitSinOutputSignal.State = ftitOutputSinVoltage;
+
+            var ftitOutputCosVoltage = 10.00 * Math.Cos(ftitOutputDegrees * Constants.RADIANS_PER_DEGREE);
+            if (ftitOutputCosVoltage < -10) ftitOutputCosVoltage = -10;
+            else if (ftitOutputCosVoltage > 10) ftitOutputCosVoltage = 10;
+            _ftitCosOutputSignal.State = ftitOutputCosVoltage;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19562HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19562HardwareSupportModuleConfig.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Malwin
+{
+    // Per-gauge calibration config for Malwin 1956-2 (F-16 FTIT Indicator).
+    // Single piecewise_resolver pair (sin/cos) — input °C maps to dial
+    // pointer angle via four linear segments (dead-band 0..200°C, then
+    // 0..100° / 100..280° / 280..320° at progressively different slopes),
+    // then sin/cos × 10 V (note: the original C# was missing the × 10
+    // multiplier; see editor file header for details).
+    [Serializable]
+    [XmlRoot(nameof(Malwin19562HardwareSupportModule))]
+    public class Malwin19562HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Malwin19562HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Malwin19562HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19563HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19563HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Malwin
 {
-    //Malwin 1956-3 F-16 Liquid Oxygen Quantity Indicator 
+    //Malwin 1956-3 F-16 Liquid Oxygen Quantity Indicator
     public class Malwin19563HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Malwin19563HardwareSupportModule));
         //There are currently No LOX QTY outputs from BMS, so there is no renderer in LightningGauges for this
         //private readonly ILiquidOxygenQuantity _renderer = new LiquidOxygenQuantity();
 
@@ -22,13 +26,95 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private bool _isDisposed;
 
-        private Malwin19563HardwareSupportModule()
+        private Malwin19563HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Malwin19563HardwareSupportModule(Malwin19563HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
             UpdateOutputValues();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolveMultiResolverPair(config,
+                "19563_LOX_SIN_To_Instrument",
+                "19563_LOX_COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+        }
+
+        private static void ResolveMultiResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "multi_resolver"
+                || !t.UnitsPerRevolution.HasValue
+                || t.UnitsPerRevolution.Value == 0
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Malwin19563HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] { _loxQtyInputSignal };
@@ -54,12 +140,23 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Malwin19563HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Malwin19563HardwareSupportModule ()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Malwin19563HardwareSupportModule.config");
+                hsmConfig = Malwin19563HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Malwin19563HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -160,6 +257,11 @@ namespace SimLinkup.HardwareSupport.Malwin
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     //Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -200,46 +302,36 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private void UpdateOutputValues()
         {
-            if (_loxQtyInputSignal != null)
+            if (_loxQtyInputSignal == null) return;
+            if (_loxQtySinOutputSignal == null || _loxQtyCosOutputSignal == null) return;
+            var loxQtyInput = _loxQtyInputSignal.State;
+            if (loxQtyInput < 0.00) loxQtyInput = 0;
+            else if (loxQtyInput > 5.00) loxQtyInput = 5.00;
+
+            // Editor override: multi_resolver pair.
+            if (_resolverTransform != null && _sinChannel != null && _cosChannel != null)
             {
-                var loxQtyInput = _loxQtyInputSignal.State;
-                double loxQtyOutputDegrees = 0;
-                if (loxQtyInput < 0.00)
-                {
-                    loxQtyInput = 0;
-                }
-                else if (loxQtyInput > 5.00)
-                {
-                    loxQtyInput = 5.00;
-                }
-
-                if (_loxQtySinOutputSignal != null && _loxQtyCosOutputSignal != null)
-                {
-                    loxQtyOutputDegrees = (loxQtyInput / 5.00) * 180.00; // 180 degrees of angle = 5 liters
-
-                    var loxQtyOutputSinVoltage = Math.Sin(loxQtyOutputDegrees * Constants.RADIANS_PER_DEGREE);
-                    if (loxQtyOutputSinVoltage < -10)
-                    {
-                        loxQtyOutputSinVoltage = -10;
-                    }
-                    else if (loxQtyOutputSinVoltage > 10)
-                    {
-                        loxQtyOutputSinVoltage = 10;
-                    }
-                    _loxQtySinOutputSignal.State = loxQtyOutputSinVoltage;
-
-                    var loxQtyOutputCosVoltage = Math.Cos(loxQtyOutputDegrees * Constants.RADIANS_PER_DEGREE);
-                    if (loxQtyOutputCosVoltage < -10)
-                    {
-                        loxQtyOutputCosVoltage = -10;
-                    }
-                    else if (loxQtyOutputCosVoltage > 10)
-                    {
-                        loxQtyOutputCosVoltage = 10;
-                    }
-                    _loxQtyCosOutputSignal.State = loxQtyOutputCosVoltage;
-                }
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluateMultiTurnResolver(
+                    loxQtyInput, t.UnitsPerRevolution.Value, t.PeakVolts.Value);
+                _loxQtySinOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _loxQtySinOutputSignal.MinValue, _loxQtySinOutputSignal.MaxValue);
+                _loxQtyCosOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _loxQtyCosOutputSignal.MinValue, _loxQtyCosOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — `(input/5) × 180°` then sin/cos × 10 V.
+            // NOTE: original C# was missing the ×10 multiplier; fixed here.
+            var loxQtyOutputDegrees = (loxQtyInput / 5.00) * 180.00;
+
+            var loxQtyOutputSinVoltage = 10.00 * Math.Sin(loxQtyOutputDegrees * Constants.RADIANS_PER_DEGREE);
+            if (loxQtyOutputSinVoltage < -10) loxQtyOutputSinVoltage = -10;
+            else if (loxQtyOutputSinVoltage > 10) loxQtyOutputSinVoltage = 10;
+            _loxQtySinOutputSignal.State = loxQtyOutputSinVoltage;
+
+            var loxQtyOutputCosVoltage = 10.00 * Math.Cos(loxQtyOutputDegrees * Constants.RADIANS_PER_DEGREE);
+            if (loxQtyOutputCosVoltage < -10) loxQtyOutputCosVoltage = -10;
+            else if (loxQtyOutputCosVoltage > 10) loxQtyOutputCosVoltage = 10;
+            _loxQtyCosOutputSignal.State = loxQtyOutputCosVoltage;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19563HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19563HardwareSupportModuleConfig.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Malwin
+{
+    // Per-gauge calibration config for Malwin 1956-3 (F-16 LOX Quantity
+    // Indicator). Single multi_resolver pair (sin/cos) — input liters maps
+    // linearly to dial pointer angle as `(input/5) × 180°`, equivalent to
+    // 10 liters per full revolution. Note: original C# was missing the ×10
+    // multiplier on the sin/cos output, so legacy installs had ±1 V output
+    // instead of ±10 V; the rewritten fallback path now applies it.
+    [Serializable]
+    [XmlRoot(nameof(Malwin19563HardwareSupportModule))]
+    public class Malwin19563HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Malwin19563HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Malwin19563HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19581HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19581HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Malwin
 {
     //Malwin 19581 F-16 HYDRAULIC PRESSURE IND
     public class Malwin19581HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Malwin19581HardwareSupportModule));
         private readonly IHydraulicPressureGauge _hydARenderer = new HydraulicPressureGauge();
         private readonly IHydraulicPressureGauge _hydBRenderer = new HydraulicPressureGauge();
         private AnalogSignal _hydPressureACOSOutputSignal;
@@ -25,12 +29,102 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private bool _isDisposed;
 
-        private Malwin19581HardwareSupportModule()
+        private Malwin19581HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _hydATransform;
+        private GaugeChannelConfig _hydASinChannel;
+        private GaugeChannelConfig _hydACosChannel;
+        private GaugeTransformConfig _hydBTransform;
+        private GaugeChannelConfig _hydBSinChannel;
+        private GaugeChannelConfig _hydBCosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Malwin19581HardwareSupportModule(Malwin19581HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolvePiecewiseResolverPair(config,
+                "19581_Hydraulic_Pressure_A_SIN_To_Instrument",
+                "19581_Hydraulic_Pressure_A_COS_To_Instrument",
+                out _hydATransform, out _hydASinChannel, out _hydACosChannel);
+            ResolvePiecewiseResolverPair(config,
+                "19581_Hydraulic_Pressure_B_SIN_To_Instrument",
+                "19581_Hydraulic_Pressure_B_COS_To_Instrument",
+                out _hydBTransform, out _hydBSinChannel, out _hydBCosChannel);
+        }
+
+        private static void ResolvePiecewiseResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "piecewise_resolver"
+                || t.Breakpoints == null
+                || t.Breakpoints.Length < 2
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Malwin19581HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateHydAOutputValues();
+                UpdateHydBOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] {_hydPressureAInputSignal, _hydPressureBInputSignal};
@@ -60,12 +154,23 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Malwin19581HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Malwin19581HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Malwin19581HardwareSupportModule.config");
+                hsmConfig = Malwin19581HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Malwin19581HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -259,6 +364,11 @@ namespace SimLinkup.HardwareSupport.Malwin
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_hydARenderer);
                     Common.Util.DisposeObject(_hydBRenderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -314,94 +424,75 @@ namespace SimLinkup.HardwareSupport.Malwin
         private void UpdateHydAOutputValues()
         {
             if (_hydPressureAInputSignal == null) return;
+            if (_hydPressureASINOutputSignal == null || _hydPressureACOSOutputSignal == null) return;
             var hydPressureAInput = _hydPressureAInputSignal.State;
-            if (_hydPressureASINOutputSignal != null)
+
+            // Editor override: piecewise_resolver pair.
+            if (_hydATransform != null && _hydASinChannel != null && _hydACosChannel != null)
             {
-                var hydPressureASINOutputValue = hydPressureAInput < 0
-                    ? 0
-                    : (hydPressureAInput > 4000
-                        ? 10.0000 * Math.Sin(320.0000 * Constants.RADIANS_PER_DEGREE)
-                        : 10.0000 *
-                          Math.Sin(hydPressureAInput / 4000 * 320.0000 *
-                                   Constants.RADIANS_PER_DEGREE));
-
-                if (hydPressureASINOutputValue < -10)
-                {
-                    hydPressureASINOutputValue = -10;
-                }
-                else if (hydPressureASINOutputValue > 10)
-                {
-                    hydPressureASINOutputValue = 10;
-                }
-
-                _hydPressureASINOutputSignal.State = hydPressureASINOutputValue;
+                var t = _hydATransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    hydPressureAInput, t.Breakpoints, t.PeakVolts.Value);
+                _hydPressureASINOutputSignal.State = _hydASinChannel.ApplyTrim(sinCos[0], _hydPressureASINOutputSignal.MinValue, _hydPressureASINOutputSignal.MaxValue);
+                _hydPressureACOSOutputSignal.State = _hydACosChannel.ApplyTrim(sinCos[1], _hydPressureACOSOutputSignal.MinValue, _hydPressureACOSOutputSignal.MaxValue);
+                return;
             }
 
-            if (_hydPressureACOSOutputSignal == null) return;
+            // Hardcoded fallback — `(input/4000) × 320°` then sin/cos × 10 V,
+            // with input < 0 parking at (0, 0) V (rest position).
+            var hydPressureASINOutputValue = hydPressureAInput < 0
+                ? 0
+                : (hydPressureAInput > 4000
+                    ? 10.0000 * Math.Sin(320.0000 * Constants.RADIANS_PER_DEGREE)
+                    : 10.0000 * Math.Sin(hydPressureAInput / 4000 * 320.0000 * Constants.RADIANS_PER_DEGREE));
+            if (hydPressureASINOutputValue < -10) hydPressureASINOutputValue = -10;
+            else if (hydPressureASINOutputValue > 10) hydPressureASINOutputValue = 10;
+            _hydPressureASINOutputSignal.State = hydPressureASINOutputValue;
+
             var hydPressureACOSOutputValue = hydPressureAInput < 0
                 ? 0
                 : (hydPressureAInput > 4000
                     ? 10.0000 * Math.Cos(320.0000 * Constants.RADIANS_PER_DEGREE)
-                    : 10.0000 *
-                      Math.Cos(hydPressureAInput / 4000.0000 * 320.0000 *
-                               Constants.RADIANS_PER_DEGREE));
-
-            if (hydPressureACOSOutputValue < -10)
-            {
-                hydPressureACOSOutputValue = -10;
-            }
-            else if (hydPressureACOSOutputValue > 10)
-            {
-                hydPressureACOSOutputValue = 10;
-            }
-
+                    : 10.0000 * Math.Cos(hydPressureAInput / 4000.0000 * 320.0000 * Constants.RADIANS_PER_DEGREE));
+            if (hydPressureACOSOutputValue < -10) hydPressureACOSOutputValue = -10;
+            else if (hydPressureACOSOutputValue > 10) hydPressureACOSOutputValue = 10;
             _hydPressureACOSOutputSignal.State = hydPressureACOSOutputValue;
         }
 
         private void UpdateHydBOutputValues()
         {
             if (_hydPressureBInputSignal == null) return;
+            if (_hydPressureBSINOutputSignal == null || _hydPressureBCOSOutputSignal == null) return;
             var hydPressureBInput = _hydPressureBInputSignal.State;
-            if (_hydPressureBSINOutputSignal != null)
+
+            // Editor override: piecewise_resolver pair.
+            if (_hydBTransform != null && _hydBSinChannel != null && _hydBCosChannel != null)
             {
-                var hydPressureBSINOutputValue = hydPressureBInput < 0
-                    ? 0
-                    : (hydPressureBInput > 4000
-                        ? 10.0000 * Math.Sin(320.0000 * Constants.RADIANS_PER_DEGREE)
-                        : 10.0000 *
-                          Math.Sin(hydPressureBInput / 4000.0000 * 320.0000 *
-                                   Constants.RADIANS_PER_DEGREE));
-
-                if (hydPressureBSINOutputValue < -10)
-                {
-                    hydPressureBSINOutputValue = -10;
-                }
-                else if (hydPressureBSINOutputValue > 10)
-                {
-                    hydPressureBSINOutputValue = 10;
-                }
-
-                _hydPressureBSINOutputSignal.State = hydPressureBSINOutputValue;
+                var t = _hydBTransform;
+                var sinCos = GaugeTransform.EvaluatePiecewiseResolver(
+                    hydPressureBInput, t.Breakpoints, t.PeakVolts.Value);
+                _hydPressureBSINOutputSignal.State = _hydBSinChannel.ApplyTrim(sinCos[0], _hydPressureBSINOutputSignal.MinValue, _hydPressureBSINOutputSignal.MaxValue);
+                _hydPressureBCOSOutputSignal.State = _hydBCosChannel.ApplyTrim(sinCos[1], _hydPressureBCOSOutputSignal.MinValue, _hydPressureBCOSOutputSignal.MaxValue);
+                return;
             }
 
-            if (_hydPressureBCOSOutputSignal == null) return;
+            // Hardcoded fallback (same as A side).
+            var hydPressureBSINOutputValue = hydPressureBInput < 0
+                ? 0
+                : (hydPressureBInput > 4000
+                    ? 10.0000 * Math.Sin(320.0000 * Constants.RADIANS_PER_DEGREE)
+                    : 10.0000 * Math.Sin(hydPressureBInput / 4000.0000 * 320.0000 * Constants.RADIANS_PER_DEGREE));
+            if (hydPressureBSINOutputValue < -10) hydPressureBSINOutputValue = -10;
+            else if (hydPressureBSINOutputValue > 10) hydPressureBSINOutputValue = 10;
+            _hydPressureBSINOutputSignal.State = hydPressureBSINOutputValue;
+
             var hydPressureBCOSOutputValue = hydPressureBInput < 0
                 ? 0
                 : (hydPressureBInput > 4000
                     ? 10.0000 * Math.Cos(320.0000 * Constants.RADIANS_PER_DEGREE)
-                    : 10.0000 *
-                      Math.Cos(hydPressureBInput / 4000.0000 * 320.0000 *
-                               Constants.RADIANS_PER_DEGREE));
-
-            if (hydPressureBCOSOutputValue < -10)
-            {
-                hydPressureBCOSOutputValue = -10;
-            }
-            else if (hydPressureBCOSOutputValue > 10)
-            {
-                hydPressureBCOSOutputValue = 10;
-            }
-
+                    : 10.0000 * Math.Cos(hydPressureBInput / 4000.0000 * 320.0000 * Constants.RADIANS_PER_DEGREE));
+            if (hydPressureBCOSOutputValue < -10) hydPressureBCOSOutputValue = -10;
+            else if (hydPressureBCOSOutputValue > 10) hydPressureBCOSOutputValue = 10;
             _hydPressureBCOSOutputSignal.State = hydPressureBCOSOutputValue;
         }
     }

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin19581HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin19581HardwareSupportModuleConfig.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Malwin
+{
+    // Per-gauge calibration config for Malwin 19581 (F-16 Hydraulic Pressure
+    // Indicator). Two independent piecewise_resolver pairs (A and B systems),
+    // each mapping 0..4000 PSI to a sin/cos resolver pair via the dial's
+    // 320° mechanical sweep.
+    [Serializable]
+    [XmlRoot(nameof(Malwin19581HardwareSupportModule))]
+    public class Malwin19581HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Malwin19581HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Malwin19581HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin246102HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin246102HardwareSupportModule.cs
@@ -1,17 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using Common.Math;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Malwin
 {
     //Malwin 246102 F-16 Cabin Pressure Altimeter
     public class Malwin246102HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Malwin246102HardwareSupportModule));
         private readonly ICabinPressureAltitudeIndicator _renderer = new CabinPressureAltitudeIndicator();
 
         private AnalogSignal _cabinPressureAltitudeCosOutputSignal;
@@ -21,12 +25,94 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private bool _isDisposed;
 
-        private Malwin246102HardwareSupportModule()
+        private Malwin246102HardwareSupportModuleConfig _config;
+        private GaugeTransformConfig _resolverTransform;
+        private GaugeChannelConfig _sinChannel;
+        private GaugeChannelConfig _cosChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Malwin246102HardwareSupportModule(Malwin246102HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            ResolveMultiResolverPair(config,
+                "246102_Cabin_Pressure_Altitude_SIN_To_Instrument",
+                "246102_Cabin_Pressure_Altitude_COS_To_Instrument",
+                out _resolverTransform, out _sinChannel, out _cosChannel);
+        }
+
+        private static void ResolveMultiResolverPair(
+            GaugeCalibrationConfig config,
+            string sinChannelId,
+            string cosChannelId,
+            out GaugeTransformConfig transform,
+            out GaugeChannelConfig sinCh,
+            out GaugeChannelConfig cosCh)
+        {
+            transform = null;
+            sinCh = null;
+            cosCh = null;
+            if (config == null) return;
+            var s = config.FindChannel(sinChannelId);
+            var c = config.FindChannel(cosChannelId);
+            if (s == null || c == null) return;
+            var t = s.Transform;
+            if (t == null
+                || t.Kind != "multi_resolver"
+                || !t.UnitsPerRevolution.HasValue
+                || t.UnitsPerRevolution.Value == 0
+                || !t.PeakVolts.HasValue)
+            {
+                return;
+            }
+            transform = t;
+            sinCh = s;
+            cosCh = c;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Malwin246102HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateCabinPressureAltitudeOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] {_cabinPressureAltitudeInputSignal};
@@ -53,12 +139,23 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Malwin246102HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Malwin246102HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Malwin246102HardwareSupportModule.config");
+                hsmConfig = Malwin246102HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Malwin246102HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -164,6 +261,11 @@ namespace SimLinkup.HardwareSupport.Malwin
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -195,47 +297,37 @@ namespace SimLinkup.HardwareSupport.Malwin
 
         private void UpdateCabinPressureAltitudeOutputValues()
         {
-            if (_cabinPressureAltitudeInputSignal != null)
+            if (_cabinPressureAltitudeInputSignal == null) return;
+            if (_cabinPressureAltitudeSinOutputSignal == null || _cabinPressureAltitudeCosOutputSignal == null) return;
+            var cabinPressureAltitudeInput = _cabinPressureAltitudeInputSignal.State;
+
+            // Editor override: multi_resolver pair.
+            if (_resolverTransform != null && _sinChannel != null && _cosChannel != null)
             {
-                var cabinPressureAltitudeInput = _cabinPressureAltitudeInputSignal.State;
-
-
-                var degrees = cabinPressureAltitudeInput < 0.0000
-                    ? 0.0000
-                    : (cabinPressureAltitudeInput >= 0 && cabinPressureAltitudeInput <= 50000.0000
-                        ? cabinPressureAltitudeInput / 50000.0000 * 300.0000
-                        : 300.0);
-
-                var cabinPressureAltitudeSinOutputValue = 10.0000 * Math.Sin(degrees * Constants.RADIANS_PER_DEGREE);
-                var cabinPressureAltitudeCosOutputValue = 10.0000 * Math.Cos(degrees * Constants.RADIANS_PER_DEGREE);
-
-
-                if (_cabinPressureAltitudeSinOutputSignal != null)
-                {
-                    if (cabinPressureAltitudeSinOutputValue < -10)
-                    {
-                        cabinPressureAltitudeSinOutputValue = -10;
-                    }
-                    else if (cabinPressureAltitudeSinOutputValue > 10)
-                    {
-                        cabinPressureAltitudeSinOutputValue = 10;
-                    }
-
-                    _cabinPressureAltitudeSinOutputSignal.State = cabinPressureAltitudeSinOutputValue;
-                }
-
-                if (_cabinPressureAltitudeCosOutputSignal == null) return;
-                if (cabinPressureAltitudeCosOutputValue < -10)
-                {
-                    cabinPressureAltitudeCosOutputValue = -10;
-                }
-                else if (cabinPressureAltitudeCosOutputValue > 10)
-                {
-                    cabinPressureAltitudeCosOutputValue = 10;
-                }
-
-                _cabinPressureAltitudeCosOutputSignal.State = cabinPressureAltitudeCosOutputValue;
+                var t = _resolverTransform;
+                var sinCos = GaugeTransform.EvaluateMultiTurnResolver(
+                    cabinPressureAltitudeInput, t.UnitsPerRevolution.Value, t.PeakVolts.Value);
+                _cabinPressureAltitudeSinOutputSignal.State = _sinChannel.ApplyTrim(sinCos[0], _cabinPressureAltitudeSinOutputSignal.MinValue, _cabinPressureAltitudeSinOutputSignal.MaxValue);
+                _cabinPressureAltitudeCosOutputSignal.State = _cosChannel.ApplyTrim(sinCos[1], _cabinPressureAltitudeCosOutputSignal.MinValue, _cabinPressureAltitudeCosOutputSignal.MaxValue);
+                return;
             }
+
+            // Hardcoded fallback — `(input/50000) × 300°` then sin/cos × 10 V.
+            var degrees = cabinPressureAltitudeInput < 0.0000
+                ? 0.0000
+                : (cabinPressureAltitudeInput >= 0 && cabinPressureAltitudeInput <= 50000.0000
+                    ? cabinPressureAltitudeInput / 50000.0000 * 300.0000
+                    : 300.0);
+
+            var cabinPressureAltitudeSinOutputValue = 10.0000 * Math.Sin(degrees * Constants.RADIANS_PER_DEGREE);
+            if (cabinPressureAltitudeSinOutputValue < -10) cabinPressureAltitudeSinOutputValue = -10;
+            else if (cabinPressureAltitudeSinOutputValue > 10) cabinPressureAltitudeSinOutputValue = 10;
+            _cabinPressureAltitudeSinOutputSignal.State = cabinPressureAltitudeSinOutputValue;
+
+            var cabinPressureAltitudeCosOutputValue = 10.0000 * Math.Cos(degrees * Constants.RADIANS_PER_DEGREE);
+            if (cabinPressureAltitudeCosOutputValue < -10) cabinPressureAltitudeCosOutputValue = -10;
+            else if (cabinPressureAltitudeCosOutputValue > 10) cabinPressureAltitudeCosOutputValue = 10;
+            _cabinPressureAltitudeCosOutputSignal.State = cabinPressureAltitudeCosOutputValue;
         }
     }
 }

--- a/src/SimLinkup/HardwareSupport/Malwin/Malwin246102HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Malwin/Malwin246102HardwareSupportModuleConfig.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Malwin
+{
+    // Per-gauge calibration config for Malwin 246102 (F-16 Cabin Pressure
+    // Altimeter). Single multi_resolver pair (sin/cos) — input ft maps
+    // linearly to dial pointer angle as `(input/50000) × 300°`, equivalent
+    // to 60000 ft per full revolution.
+    [Serializable]
+    [XmlRoot(nameof(Malwin246102HardwareSupportModule))]
+    public class Malwin246102HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Malwin246102HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Malwin246102HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Westin/Westin521993HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Westin/Westin521993HardwareSupportModule.cs
@@ -1,30 +1,96 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Westin
 {
     //Westin P/N 521993 F-16 EPU FUEL QTY IND
     public class Westin521993HardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(Westin521993HardwareSupportModule));
         private readonly IEPUFuelGauge _renderer = new EPUFuelGauge();
 
         private AnalogSignal _epuFuelPercentageInputSignal;
         private AnalogSignal.AnalogSignalChangedEventHandler _epuFuelPercentageInputSignalChangedEventHandler;
         private AnalogSignal _epuFuelPercentageOutputSignal;
-
         private bool _isDisposed;
 
-        private Westin521993HardwareSupportModule()
+        private Westin521993HardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _epuChannel;
+        private ConfigFileReloadWatcher _configWatcher;
+
+        public Westin521993HardwareSupportModule(Westin521993HardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateOutputSignals();
             CreateInputEventHandlers();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _epuChannel = ResolvePiecewiseChannel(config, "521993_EPU_To_Instrument");
+        }
+
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = Westin521993HardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                // Re-evaluate every output with the cached input values so the
+                // user sees the new calibration immediately. Without this,
+                // SimLinkup's event-driven update loop won't fire until the
+                // simulator next pushes a new input value.
+                UpdateOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[] {_epuFuelPercentageInputSignal};
@@ -50,12 +116,23 @@ namespace SimLinkup.HardwareSupport.Westin
 
         public static IHardwareSupportModule[] GetInstances()
         {
-            var toReturn = new List<IHardwareSupportModule>
+            Westin521993HardwareSupportModuleConfig hsmConfig = null;
+            try
             {
-                new Westin521993HardwareSupportModule()
-            };
-
-            return toReturn.ToArray();
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "Westin521993HardwareSupportModule.config");
+                hsmConfig = Westin521993HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new Westin521993HardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -135,6 +212,11 @@ namespace SimLinkup.HardwareSupport.Westin
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -172,19 +254,21 @@ namespace SimLinkup.HardwareSupport.Westin
         private void UpdateOutputValues()
         {
             if (_epuFuelPercentageInputSignal == null) return;
-            var epuInput = _epuFuelPercentageInputSignal.State;
             if (_epuFuelPercentageOutputSignal == null) return;
+            var epuInput = _epuFuelPercentageInputSignal.State;
+
+            // Editor override: piecewise channel.
+            if (_epuChannel != null)
+            {
+                var v = GaugeTransform.EvaluatePiecewise(epuInput, _epuChannel.Transform.Breakpoints);
+                _epuFuelPercentageOutputSignal.State = _epuChannel.ApplyTrim(v, _epuFuelPercentageOutputSignal.MinValue, _epuFuelPercentageOutputSignal.MaxValue);
+                return;
+            }
+
+            // Hardcoded fallback — 0..100% mapped to 0.1..2.0 V.
             var epuOutputValue = epuInput < 0 ? 0.1 : (epuInput > 100 ? 2 : epuInput / 100 * 1.9 + 0.1);
-
-            if (epuOutputValue < 0)
-            {
-                epuOutputValue = 0.1;
-            }
-            else if (epuOutputValue > 2)
-            {
-                epuOutputValue = 2;
-            }
-
+            if (epuOutputValue < 0) epuOutputValue = 0.1;
+            else if (epuOutputValue > 2) epuOutputValue = 2;
             _epuFuelPercentageOutputSignal.State = epuOutputValue;
         }
     }

--- a/src/SimLinkup/HardwareSupport/Westin/Westin521993HardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Westin/Westin521993HardwareSupportModuleConfig.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Westin
+{
+    // Per-gauge calibration config for Westin 521993 (F-16 EPU Fuel Quantity
+    // Indicator). Single piecewise channel — output is an unusual 0.1..2.0 V
+    // range driving a low-voltage hot-wire EPU hydrazine gauge directly.
+    [Serializable]
+    [XmlRoot(nameof(Westin521993HardwareSupportModule))]
+    public class Westin521993HardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+        public static Westin521993HardwareSupportModuleConfig Load(string filePath)
+        {
+            return GaugeCalibrationConfig.Load<Westin521993HardwareSupportModuleConfig>(filePath);
+        }
+    }
+}

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -124,9 +124,13 @@
     </EmbeddedResource>
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HardwareSupport\AMI\AMI9000262001HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\AMI\AMI9000262001HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\AMI\AMI900158001HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\AMI\AMI900158001HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\AMI\AMI9001584HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\AMI\AMI9001584HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\AMI\AMI9002780-02HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\AMI\AMI9002780-02HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\AnalogDevices\AnalogDevicesHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\AnalogDevices\AnalogDevicesHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\ArduinoSeat\ArduinoSeatCommunicationProtocolHeaders.cs" />
@@ -134,8 +138,10 @@
     <Compile Include="HardwareSupport\ArduinoSeat\ArduinoSeatHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\ArduinoSeat\SeatOutput.cs" />
     <Compile Include="HardwareSupport\Astronautics\Astronautics12871HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Astronautics\Astronautics12871HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\DirectInput\DirectInputHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Gould\GouldHS070D51341HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Gould\GouldHS070D51341HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\ADI\HenkF16ADISupportBoardHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModuleConfig.cs" />
@@ -150,11 +156,17 @@
     <Compile Include="HardwareSupport\Henk\SDI\HenkSDIHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\SDI\HenkSDIHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Lilbern\Lilbern3321HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Lilbern\Lilbern3321HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Lilbern\Lilbern3239HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Lilbern\Lilbern3239HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Malwin\Malwin19562HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Malwin\Malwin19562HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Malwin\Malwin19563HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Malwin\Malwin19563HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Malwin\Malwin19581HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Malwin\Malwin19581HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Malwin\Malwin246102HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Malwin\Malwin246102HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\MDI\DataEntryDisplayPilotFaultListHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\MDI\DataEntryDisplayPilotFaultListHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\NiclasMorin\DTSCard\DTSCardHardwareSupportModule.cs" />
@@ -200,6 +212,7 @@
     <Compile Include="HardwareSupport\TeensyRWR\TeensyRWRHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\TeensyRWR\TeensyRWRHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Westin\Westin521993HardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Westin\Westin521993HardwareSupportModuleConfig.cs" />
     <Compile Include="PacketEncoding\COBS.cs" />
     <Compile Include="Runtime\Runtime.cs" />
     <Compile Include="Runtime\SimSupportModuleLoader.cs" />


### PR DESCRIPTION
Adds per-gauge `XHardwareSupportModuleConfig.cs` files (thin subclasses of `GaugeCalibrationConfig` from #14) and updates the matching gauge HSMs to consume them. Companion to #16 (Simtek) \xe2\x80\x94 same pattern, different manufacturers.

Each HSM:
- Holds its config object on the instance, loaded in `GetInstances` from `<ProfileDir>/XHardwareSupportModule.config`
- Resolves channel-by-channel into typed pointers so `Update*OutputValues` can fast-path between hardcoded fallback and editor-authored override
- Hot-reloads via `Common.HardwareSupport.Calibration.ConfigFileReloadWatcher` (#13). `ReloadConfig` calls every per-HSM `Update*OutputValues` at the end so the gauge reflects the new calibration immediately, without waiting for the next sim input change.

Schema is opt-in per gauge: when the `.config` file is missing or fails to parse, every HSM falls through to its existing hardcoded behaviour.

**Affected gauges (13):**

| Manufacturer | PN | Gauge | Channels |
|--------------|----|----|---|
| AMI | 9000262-01 | cabin pressure altimeter | 1 |
| AMI | 900158-001 | HSI | 11 (bearing, compass, course-dev, course, dev-flag, DME, DME-shutter, from-flag, heading, off-flag, to-flag) |
| AMI | 9001584 | fuel quantity indicator | 1 |
| AMI | 9002780-02 | ADI | 9 (aux/GS/LOC/OFF flags, horizontal cmd bar, pitch, rate-of-turn, roll, vertical cmd bar) |
| Astronautics | 12871 | ADI | 10 (AMI 9002780-02 set + inclinometer) |
| Gould | HS070D5134-1 | standby compass | 1 |
| Lilbern | 3239 | fuel flow indicator | 1 |
| Lilbern | 3321 | tachometer | 1 |
| Malwin | 1956-2 | FTIT | 1 |
| Malwin | 1956-3 | simulated liquid oxygen quantity | 1 |
| Malwin | 19581 | hydraulic pressure | 2 (HydA + HydB) |
| Malwin | 246102 | cabin pressure altimeter | 1 |
| Westin | 521993 | attitude indicator | 1 |

27 files changed (13 HSM mods + 13 new Config subclasses + csproj).

---

**Stacked on #13 and #14**: this branch is based on top of `pr/gauge-calibration-config` (#14) which itself is on top of `pr/config-file-reload-watcher` (#13). Sibling to #16 (Simtek). For a clean review chain: #13 \xe2\x86\x92 #14 \xe2\x86\x92 (#15 || #16 || this PR, in any order).