### PR TITLE
ArduinoSeat HSM: 5 motor-output bug fixes + watcher migration

### DIFF
--- a/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
+++ b/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
@@ -1,0 +1,264 @@
+using System;
+using System.IO;
+using System.Threading;
+using log4net;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Resilient file watcher for editor-authored gauge config files.
+    //
+    // Replaces the per-HSM FileSystemWatcher boilerplate with three layers
+    // of defence against the well-known Windows file-watching failure
+    // modes:
+    //
+    //   1. InternalBufferSize bumped to 64 KB (max safe value before the
+    //      kernel starts dropping events). Avoids transient buffer
+    //      overflows during bursty multi-gauge saves.
+    //
+    //   2. Error event handler. When the watcher reports an internal
+    //      error (most commonly buffer overflow), dispose the watcher
+    //      and create a fresh one on a background timer beat.
+    //
+    //   3. Periodic resubscribe (every 30 s). Several Windows scenarios
+    //      silently orphan a FileSystemWatcher without firing an Error
+    //      event — antivirus / OneDrive / SMB filter drivers can drop
+    //      the IOCP completion notifications mid-flight, leaving the
+    //      watcher object alive but deaf. Periodic recreation guarantees
+    //      the watcher is fresh at most every 30 s. Belt-and-braces.
+    //
+    //   4. Mtime poll fallback (every 5 s). Even if all three watcher
+    //      layers fail, a polling timer reads the file's
+    //      LastWriteTime and triggers a reload when it changes. This
+    //      guarantees worst-case ~5 s latency between editor save and
+    //      gauge reload, even when the watcher is completely broken.
+    //
+    // Per-HSM usage:
+    //
+    //     // In the HSM's field section
+    //     private ConfigFileReloadWatcher _configWatcher;
+    //
+    //     // In StartConfigWatcher (or equivalent)
+    //     _configWatcher = new ConfigFileReloadWatcher(
+    //         _config.FilePath, ReloadConfig);
+    //
+    //     // In Dispose
+    //     if (_configWatcher != null) {
+    //         _configWatcher.Dispose();
+    //         _configWatcher = null;
+    //     }
+    //
+    //     // The HSM's existing reload method:
+    //     private void ReloadConfig() {
+    //         var reloaded = MyHardwareSupportModuleConfig.Load(_config.FilePath);
+    //         if (reloaded == null) return;
+    //         reloaded.FilePath = _config.FilePath;
+    //         _config = reloaded;
+    //         ResolveAllChannels(reloaded);
+    //     }
+    //
+    // The helper handles all dedup internally; the HSM's onChange callback
+    // can assume the file actually changed since the last call.
+    public sealed class ConfigFileReloadWatcher : IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(ConfigFileReloadWatcher));
+
+        // 30 s resubscribe and 5 s poll cadence picked as a compromise:
+        // fast enough that a "watcher silently died" scenario heals in
+        // about as long as it takes the user to retry a save, slow
+        // enough to cost ~negligible CPU when nothing is happening.
+        private const int RESUBSCRIBE_INTERVAL_MS = 30 * 1000;
+        private const int POLL_INTERVAL_MS = 5 * 1000;
+        private const int INTERNAL_BUFFER_SIZE = 64 * 1024;  // 64 KB max safe
+
+        private readonly string _filePath;
+        private readonly Action _onChange;
+        private readonly object _lock = new object();
+
+        private FileSystemWatcher _watcher;
+        private Timer _resubscribeTimer;
+        private Timer _pollTimer;
+        private DateTime _lastSeenWriteTime = DateTime.MinValue;
+        private bool _isDisposed;
+
+        public ConfigFileReloadWatcher(string filePath, Action onChange)
+        {
+            if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException("filePath");
+            if (onChange == null) throw new ArgumentNullException("onChange");
+            _filePath = filePath;
+            _onChange = onChange;
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    _lastSeenWriteTime = File.GetLastWriteTimeUtc(_filePath);
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Warn("Could not read initial mtime for " + _filePath + ": " + e.Message);
+            }
+            CreateWatcher();
+            // Resubscribe periodically to recover from silent orphaning.
+            _resubscribeTimer = new Timer(
+                _ => RecreateWatcher(reason: "periodic"),
+                state: null,
+                dueTime: RESUBSCRIBE_INTERVAL_MS,
+                period: RESUBSCRIBE_INTERVAL_MS);
+            // Poll mtime as a worst-case fallback.
+            _pollTimer = new Timer(
+                _ => PollOnce(),
+                state: null,
+                dueTime: POLL_INTERVAL_MS,
+                period: POLL_INTERVAL_MS);
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                if (_resubscribeTimer != null)
+                {
+                    try { _resubscribeTimer.Dispose(); } catch { }
+                    _resubscribeTimer = null;
+                }
+                if (_pollTimer != null)
+                {
+                    try { _pollTimer.Dispose(); } catch { }
+                    _pollTimer = null;
+                }
+                DisposeWatcher();
+            }
+        }
+
+        // Called from constructor and RecreateWatcher. Caller must hold
+        // the lock when entering from RecreateWatcher; constructor is
+        // single-threaded so it doesn't need to.
+        private void CreateWatcher()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                var name = Path.GetFileName(_filePath);
+                if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name)) return;
+                if (!Directory.Exists(dir)) return;
+                var w = new FileSystemWatcher(dir, name)
+                {
+                    InternalBufferSize = INTERNAL_BUFFER_SIZE,
+                    NotifyFilter = NotifyFilters.LastWrite
+                                 | NotifyFilters.Size
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.CreationTime,
+                };
+                // Watch all the events that can signal a save: Changed for
+                // in-place truncate-write (Node fs.writeFileSync), Created
+                // for atomic-replace patterns (rename-into-place), and
+                // Renamed for editors that use a temp file then rename.
+                w.Changed += OnFsEvent;
+                w.Created += OnFsEvent;
+                w.Renamed += OnFsRenamed;
+                w.Error += OnFsError;
+                w.EnableRaisingEvents = true;
+                _watcher = w;
+            }
+            catch (Exception e)
+            {
+                _log.Error("Could not create FileSystemWatcher for " + _filePath + ": " + e.Message, e);
+            }
+        }
+
+        private void DisposeWatcher()
+        {
+            var w = _watcher;
+            _watcher = null;
+            if (w == null) return;
+            try { w.EnableRaisingEvents = false; } catch { }
+            try { w.Changed -= OnFsEvent; } catch { }
+            try { w.Created -= OnFsEvent; } catch { }
+            try { w.Renamed -= OnFsRenamed; } catch { }
+            try { w.Error -= OnFsError; } catch { }
+            try { w.Dispose(); } catch { }
+        }
+
+        private void RecreateWatcher(string reason)
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                DisposeWatcher();
+                CreateWatcher();
+            }
+            // After recreating, also poll once in case the file changed
+            // during the brief window where we had no watcher armed.
+            PollOnce();
+        }
+
+        private void OnFsEvent(object sender, FileSystemEventArgs e)
+        {
+            MaybeFireReload();
+        }
+
+        private void OnFsRenamed(object sender, RenamedEventArgs e)
+        {
+            // Atomic-replace patterns rename the new file INTO the watched
+            // name, so the rename event signals a fresh file is in place.
+            MaybeFireReload();
+        }
+
+        private void OnFsError(object sender, ErrorEventArgs e)
+        {
+            // Most common cause: internal buffer overflow. Dispose and
+            // recreate the watcher; the poll timer will catch any
+            // mtime change that happened between events.
+            var ex = e.GetException();
+            _log.Warn("FileSystemWatcher error for " + _filePath +
+                ": " + (ex != null ? ex.Message : "unknown") +
+                " — recreating watcher");
+            RecreateWatcher(reason: "error");
+        }
+
+        private void PollOnce()
+        {
+            if (_isDisposed) return;
+            MaybeFireReload();
+        }
+
+        // Single source of truth for "should we tell the HSM to reload?"
+        // Compares the file's current LastWriteTimeUtc against the last
+        // value we successfully reloaded for. Returns early when nothing
+        // has changed. Synchronised so multiple watcher events firing
+        // close together (or a watcher event arriving the same instant
+        // the poll timer ticks) collapse into a single reload.
+        private void MaybeFireReload()
+        {
+            DateTime now;
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                try
+                {
+                    if (!File.Exists(_filePath)) return;
+                    now = File.GetLastWriteTimeUtc(_filePath);
+                }
+                catch
+                {
+                    return;
+                }
+                if (now == _lastSeenWriteTime) return;
+                _lastSeenWriteTime = now;
+            }
+            // Invoke the HSM's reload callback OUTSIDE the lock so a slow
+            // reload (XML parse + channel re-resolve) doesn't block other
+            // threads that want to fire events while we're working.
+            try
+            {
+                _onChange();
+            }
+            catch (Exception e)
+            {
+                _log.Error("Reload callback failed for " + _filePath + ": " + e.Message, e);
+            }
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -39,6 +39,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/SimLinkup/HardwareSupport/ArduinoSeat/ArduinoSeatHardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/ArduinoSeat/ArduinoSeatHardwareSupportModule.cs
@@ -1,4 +1,5 @@
 ﻿using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.IO.Ports;
 using Common.MacroProgramming;
 using log4net;
@@ -89,29 +90,56 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
 
         private AnalogSignal _bytesSentSignal;
 
-        private FileSystemWatcher _configFileWatcher;
+        // Watcher fires ReloadConfig on a background thread when the
+        // editor saves the config file. ConfigFileReloadWatcher handles
+        // the unreliable bits (silent watcher orphaning under AV /
+        // OneDrive / SMB filter drivers, mtime dedup, internal buffer
+        // overflow). _configChanged is held true for the duration of
+        // the swap so UpdateOutputs (which serialises a packet over the
+        // serial port) skips one frame instead of writing a half-loaded
+        // config — single-step pointer reassignments would be safe but
+        // a packet built mid-swap could mix old and new field bytes.
+        private ConfigFileReloadWatcher _configWatcher;
         private bool _configChanged = false;
-        private DateTime _lastConfigModified = DateTime.MinValue;
 
         public ArduinoSeatHardwareSupportModule(ArduinoSeatHardwareSupportModuleConfig config)
         {
             _config = config;
             CreateSignals(out _analogSignals, out _digitalSignals);
-
-            _configFileWatcher = new FileSystemWatcher(Path.GetDirectoryName(_config.FilePath), Path.GetFileName(_config.FilePath));
-            _configFileWatcher.Changed += _config_Changed;
-            _configFileWatcher.EnableRaisingEvents = true;
+            StartConfigWatcher();
         }
 
-        private void _config_Changed(object sender, FileSystemEventArgs e)
+        private void StartConfigWatcher()
         {
-            if (_lastConfigModified != File.GetLastWriteTime(_config.FilePath))
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
             {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
                 _configChanged = true;
-                var configfile = _config.FilePath;
-                _config = ArduinoSeatHardwareSupportModuleConfig.Load(configfile);
-                _config.FilePath = configfile;
-                _lastConfigModified = File.GetLastWriteTime(_config.FilePath);
+                var reloaded = ArduinoSeatHardwareSupportModuleConfig.Load(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
+            finally
+            {
                 _configChanged = false;
             }
         }
@@ -1025,14 +1053,22 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
 
             if (!_isExitGame.State && !_isFrozen.State && !_isPaused.State && !_endOfFlight.State && _in3D.State)
             {
-                if (_gunIsFiring.State)
-                    SetMotorOutputs(_gunIsFiring.Id, _gunIsFiring.State ? 1 : 0, true, ref motorBits, ref motorSpeeds);
-
-                if (_bumpIntensity.State > 0)
-                    SetMotorOutputs(_bumpIntensity.Id, _bumpIntensity.State, false, ref motorBits, ref motorSpeeds);
-
-                if (_nozzle1Position.State > 0)
-                    SetMotorOutputs(_nozzle1Position.Id, _nozzle1Position.State, false, ref motorBits, ref motorSpeeds);
+                // Walk every digital input — any signal currently asserted may
+                // drive its configured motors. CalcMotorSpeed handles the per-
+                // output FORCE/TYPE/MIN/MAX gating, so we don't pre-filter.
+                foreach (var sig in _digitalSignals)
+                {
+                    if (sig.State)
+                        SetMotorOutputs(sig.Id, 1, true, ref motorBits, ref motorSpeeds);
+                }
+                // Walk every analog input — CalcMotorSpeed clamps via MIN/MAX
+                // so a zero-state signal whose MIN is 0 still drives correctly.
+                // Skip the publishing-only signals that aren't sim inputs.
+                foreach (var sig in _analogSignals)
+                {
+                    if (sig == _bytesSentSignal) continue;
+                    SetMotorOutputs(sig.Id, sig.State, false, ref motorBits, ref motorSpeeds);
+                }
             }
 
             byte[] packet = null;
@@ -1106,19 +1142,32 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
         {
             byte motorSpeed = 0;
 
+            // Off means "this output never drives a motor", regardless of
+            // pulse type. Without this short-circuit the Progressive and
+            // CenterPeak branches would compute non-zero speeds even when
+            // the user explicitly set FORCE=Off; only the Fixed branch
+            // honoured Off via its inner switch.
+            if (output.FORCE == MotorForce.Off) return 0;
+
             if (isDigital || simValue >= output.MIN && simValue <= output.MAX)
             {
                 switch (output.TYPE)
                 {
                     case PulseType.Fixed:
                         if (output.FORCE == MotorForce.Manual)
-                            motorSpeed = output.MOTOR_1_SPEED;
+                            // Use the per-motor speed the caller passed in
+                            // (output.MOTOR_<N>_SPEED) so motors 2–4 don't all
+                                // collapse onto motor 1's configured value.
+                            motorSpeed = maxMotorSpeed;
                         else
                         {
                             switch (output.FORCE)
                             {
                                 case MotorForce.Off:
                                     motorSpeed = 0;
+                                    break;
+                                case MotorForce.Slight:
+                                    motorSpeed = _config.ForceSlight;
                                     break;
                                 case MotorForce.Rumble:
                                     motorSpeed = _config.ForceRumble;
@@ -1144,6 +1193,12 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
                         break;
                     case PulseType.CenterPeak:
                         {
+                            // Symmetric tent: ramp 0→max as simValue goes from
+                            // MIN to midpoint, then ramp max→0 from midpoint
+                            // to MAX. The previous else-branch used a
+                            // hyperbolic decay (totalDelta / (simValue-MIN))
+                            // that bottoms out at 0.5*max at simValue==MAX
+                            // instead of returning to 0.
                             var totalDelta = (output.MAX - output.MIN) / 2;
                             if (totalDelta > 0)
                             {
@@ -1154,7 +1209,7 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
                                 }
                                 else
                                 {
-                                    double calculatedSpeed = (totalDelta / (simValue - output.MIN)) * maxMotorSpeed;
+                                    double calculatedSpeed = ((output.MAX - simValue) / totalDelta) * maxMotorSpeed;
                                     motorSpeed = (byte)calculatedSpeed;
                                 }
                             }
@@ -1279,6 +1334,11 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
                 catch (Exception e)
                 {
                     _log.Error(e.Message, e);
+                }
+                if (_configWatcher != null)
+                {
+                    try { _configWatcher.Dispose(); } catch { }
+                    _configWatcher = null;
                 }
             }
             _isDisposed = true;

--- a/src/SimLinkup/HardwareSupport/ArduinoSeat/SeatOutput.cs
+++ b/src/SimLinkup/HardwareSupport/ArduinoSeat/SeatOutput.cs
@@ -53,6 +53,7 @@ namespace SimLinkup.HardwareSupport.ArduinoSeat
     {
         Manual,
         Off,
+        Slight,
         Rumble,
         Medium,
         Hard


### PR DESCRIPTION
Five long-standing bugs in the per-output motor driver path that prevent the `.config` file's `FORCE` / `TYPE` / motor-speed / `MIN`-`MAX` fields from taking effect at runtime. All confined to `CalcMotorSpeed` and the `UpdateOutputs` caller. Plus a missing `MotorForce.Slight` enum value and a watcher migration / dispose fix.

### Bug 1: `UpdateOutputs` hardcoded 3 sim signals

Only `_gunIsFiring`, `_bumpIntensity`, `_nozzle1Position` could ever drive motors \xe2\x80\x94 every other digital and analog signal in the user's config was ignored. Replaced the hand-picked branches with a walk over `_digitalSignals` + `_analogSignals`, letting `CalcMotorSpeed`'s per-output `FORCE`/`TYPE`/`MIN`/`MAX` gating decide what fires.

### Bug 2: `MotorForce.Off` ignored outside the `Fixed` pulse type

Only the `Fixed` pulse type's inner switch honoured `Off`; the `Progressive` and `CenterPeak` branches happily computed non-zero motor speeds even when the user had explicitly set `FORCE=Off`. Added an early return at the top of `CalcMotorSpeed`.

### Bug 3: Per-motor speed collapsed onto motor 1's value

The `Manual`/`Fixed` branch hardcoded `motorSpeed = output.MOTOR_1_SPEED`, so motors 2/3/4 all ran at motor 1's configured speed regardless of their own `MOTOR_<N>_SPEED` setting. Use the `maxMotorSpeed` parameter the caller already passes (which is the per-motor speed for the motor currently being computed).

### Bug 4: `MotorForce.Slight` enum value was missing

`ArduinoSeatHardwareSupportModuleConfig` has a `ForceSlight` byte field, but the `MotorForce` enum had `Manual`/`Off`/`Rumble`/`Medium`/`Hard` \xe2\x80\x94 no `Slight`. Any output configured with `FORCE=Slight` would fall through `CalcMotorSpeed`'s switch and produce 0. Added `Slight` to both the enum (in `SeatOutput.cs`) and the `CalcMotorSpeed` switch.

### Bug 5: `CenterPeak` falling-edge math was hyperbolic, not symmetric

The else-branch used `(totalDelta / (simValue - MIN)) * maxMotorSpeed`, which decays as `1/x` and bottoms out at `0.5 * maxMotorSpeed` when `simValue == MAX` instead of returning to 0. Replaced with the symmetric ramp `((MAX - simValue) / totalDelta) * maxMotorSpeed` so the speed climbs `0 \xe2\x86\x92 max` from `MIN` to midpoint and falls `max \xe2\x86\x92 0` from midpoint to `MAX` (proper tent shape).

### Watcher migration

The HSM previously held a raw `FileSystemWatcher` and never disposed it (per-instance leak across HSM lifecycle). Replaced with `Common.HardwareSupport.Calibration.ConfigFileReloadWatcher` (#13) for the same Windows-watcher-resilience reasons as the gauge HSMs. Preserved the `_configChanged` guard around the swap so `UpdateOutputs` (which serialises a packet over the serial port) skips one frame instead of writing a half-loaded config \xe2\x80\x94 single-step pointer reassignments would be safe but a packet built mid-swap could mix old and new field bytes. Added proper `Dispose` of the watcher.

2 files changed, 82 insertions, 21 deletions.

---

**Stacked on #13** (`ConfigFileReloadWatcher` helper). For a clean review chain: merge #13 first, then this.