### PR TITLE
HenkieF16FuelFlow: read unified-schema calibration file from editor

### DIFF
--- a/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
+++ b/src/Common/HardwareSupport/Calibration/ConfigFileReloadWatcher.cs
@@ -1,0 +1,264 @@
+using System;
+using System.IO;
+using System.Threading;
+using log4net;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Resilient file watcher for editor-authored gauge config files.
+    //
+    // Replaces the per-HSM FileSystemWatcher boilerplate with three layers
+    // of defence against the well-known Windows file-watching failure
+    // modes:
+    //
+    //   1. InternalBufferSize bumped to 64 KB (max safe value before the
+    //      kernel starts dropping events). Avoids transient buffer
+    //      overflows during bursty multi-gauge saves.
+    //
+    //   2. Error event handler. When the watcher reports an internal
+    //      error (most commonly buffer overflow), dispose the watcher
+    //      and create a fresh one on a background timer beat.
+    //
+    //   3. Periodic resubscribe (every 30 s). Several Windows scenarios
+    //      silently orphan a FileSystemWatcher without firing an Error
+    //      event — antivirus / OneDrive / SMB filter drivers can drop
+    //      the IOCP completion notifications mid-flight, leaving the
+    //      watcher object alive but deaf. Periodic recreation guarantees
+    //      the watcher is fresh at most every 30 s. Belt-and-braces.
+    //
+    //   4. Mtime poll fallback (every 5 s). Even if all three watcher
+    //      layers fail, a polling timer reads the file's
+    //      LastWriteTime and triggers a reload when it changes. This
+    //      guarantees worst-case ~5 s latency between editor save and
+    //      gauge reload, even when the watcher is completely broken.
+    //
+    // Per-HSM usage:
+    //
+    //     // In the HSM's field section
+    //     private ConfigFileReloadWatcher _configWatcher;
+    //
+    //     // In StartConfigWatcher (or equivalent)
+    //     _configWatcher = new ConfigFileReloadWatcher(
+    //         _config.FilePath, ReloadConfig);
+    //
+    //     // In Dispose
+    //     if (_configWatcher != null) {
+    //         _configWatcher.Dispose();
+    //         _configWatcher = null;
+    //     }
+    //
+    //     // The HSM's existing reload method:
+    //     private void ReloadConfig() {
+    //         var reloaded = MyHardwareSupportModuleConfig.Load(_config.FilePath);
+    //         if (reloaded == null) return;
+    //         reloaded.FilePath = _config.FilePath;
+    //         _config = reloaded;
+    //         ResolveAllChannels(reloaded);
+    //     }
+    //
+    // The helper handles all dedup internally; the HSM's onChange callback
+    // can assume the file actually changed since the last call.
+    public sealed class ConfigFileReloadWatcher : IDisposable
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(ConfigFileReloadWatcher));
+
+        // 30 s resubscribe and 5 s poll cadence picked as a compromise:
+        // fast enough that a "watcher silently died" scenario heals in
+        // about as long as it takes the user to retry a save, slow
+        // enough to cost ~negligible CPU when nothing is happening.
+        private const int RESUBSCRIBE_INTERVAL_MS = 30 * 1000;
+        private const int POLL_INTERVAL_MS = 5 * 1000;
+        private const int INTERNAL_BUFFER_SIZE = 64 * 1024;  // 64 KB max safe
+
+        private readonly string _filePath;
+        private readonly Action _onChange;
+        private readonly object _lock = new object();
+
+        private FileSystemWatcher _watcher;
+        private Timer _resubscribeTimer;
+        private Timer _pollTimer;
+        private DateTime _lastSeenWriteTime = DateTime.MinValue;
+        private bool _isDisposed;
+
+        public ConfigFileReloadWatcher(string filePath, Action onChange)
+        {
+            if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException("filePath");
+            if (onChange == null) throw new ArgumentNullException("onChange");
+            _filePath = filePath;
+            _onChange = onChange;
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    _lastSeenWriteTime = File.GetLastWriteTimeUtc(_filePath);
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Warn("Could not read initial mtime for " + _filePath + ": " + e.Message);
+            }
+            CreateWatcher();
+            // Resubscribe periodically to recover from silent orphaning.
+            _resubscribeTimer = new Timer(
+                _ => RecreateWatcher(reason: "periodic"),
+                state: null,
+                dueTime: RESUBSCRIBE_INTERVAL_MS,
+                period: RESUBSCRIBE_INTERVAL_MS);
+            // Poll mtime as a worst-case fallback.
+            _pollTimer = new Timer(
+                _ => PollOnce(),
+                state: null,
+                dueTime: POLL_INTERVAL_MS,
+                period: POLL_INTERVAL_MS);
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                if (_resubscribeTimer != null)
+                {
+                    try { _resubscribeTimer.Dispose(); } catch { }
+                    _resubscribeTimer = null;
+                }
+                if (_pollTimer != null)
+                {
+                    try { _pollTimer.Dispose(); } catch { }
+                    _pollTimer = null;
+                }
+                DisposeWatcher();
+            }
+        }
+
+        // Called from constructor and RecreateWatcher. Caller must hold
+        // the lock when entering from RecreateWatcher; constructor is
+        // single-threaded so it doesn't need to.
+        private void CreateWatcher()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                var name = Path.GetFileName(_filePath);
+                if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(name)) return;
+                if (!Directory.Exists(dir)) return;
+                var w = new FileSystemWatcher(dir, name)
+                {
+                    InternalBufferSize = INTERNAL_BUFFER_SIZE,
+                    NotifyFilter = NotifyFilters.LastWrite
+                                 | NotifyFilters.Size
+                                 | NotifyFilters.FileName
+                                 | NotifyFilters.CreationTime,
+                };
+                // Watch all the events that can signal a save: Changed for
+                // in-place truncate-write (Node fs.writeFileSync), Created
+                // for atomic-replace patterns (rename-into-place), and
+                // Renamed for editors that use a temp file then rename.
+                w.Changed += OnFsEvent;
+                w.Created += OnFsEvent;
+                w.Renamed += OnFsRenamed;
+                w.Error += OnFsError;
+                w.EnableRaisingEvents = true;
+                _watcher = w;
+            }
+            catch (Exception e)
+            {
+                _log.Error("Could not create FileSystemWatcher for " + _filePath + ": " + e.Message, e);
+            }
+        }
+
+        private void DisposeWatcher()
+        {
+            var w = _watcher;
+            _watcher = null;
+            if (w == null) return;
+            try { w.EnableRaisingEvents = false; } catch { }
+            try { w.Changed -= OnFsEvent; } catch { }
+            try { w.Created -= OnFsEvent; } catch { }
+            try { w.Renamed -= OnFsRenamed; } catch { }
+            try { w.Error -= OnFsError; } catch { }
+            try { w.Dispose(); } catch { }
+        }
+
+        private void RecreateWatcher(string reason)
+        {
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                DisposeWatcher();
+                CreateWatcher();
+            }
+            // After recreating, also poll once in case the file changed
+            // during the brief window where we had no watcher armed.
+            PollOnce();
+        }
+
+        private void OnFsEvent(object sender, FileSystemEventArgs e)
+        {
+            MaybeFireReload();
+        }
+
+        private void OnFsRenamed(object sender, RenamedEventArgs e)
+        {
+            // Atomic-replace patterns rename the new file INTO the watched
+            // name, so the rename event signals a fresh file is in place.
+            MaybeFireReload();
+        }
+
+        private void OnFsError(object sender, ErrorEventArgs e)
+        {
+            // Most common cause: internal buffer overflow. Dispose and
+            // recreate the watcher; the poll timer will catch any
+            // mtime change that happened between events.
+            var ex = e.GetException();
+            _log.Warn("FileSystemWatcher error for " + _filePath +
+                ": " + (ex != null ? ex.Message : "unknown") +
+                " — recreating watcher");
+            RecreateWatcher(reason: "error");
+        }
+
+        private void PollOnce()
+        {
+            if (_isDisposed) return;
+            MaybeFireReload();
+        }
+
+        // Single source of truth for "should we tell the HSM to reload?"
+        // Compares the file's current LastWriteTimeUtc against the last
+        // value we successfully reloaded for. Returns early when nothing
+        // has changed. Synchronised so multiple watcher events firing
+        // close together (or a watcher event arriving the same instant
+        // the poll timer ticks) collapse into a single reload.
+        private void MaybeFireReload()
+        {
+            DateTime now;
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+                try
+                {
+                    if (!File.Exists(_filePath)) return;
+                    now = File.GetLastWriteTimeUtc(_filePath);
+                }
+                catch
+                {
+                    return;
+                }
+                if (now == _lastSeenWriteTime) return;
+                _lastSeenWriteTime = now;
+            }
+            // Invoke the HSM's reload callback OUTSIDE the lock so a slow
+            // reload (XML parse + channel re-resolve) doesn't block other
+            // threads that want to fire events while we're working.
+            try
+            {
+                _onChange();
+            }
+            catch (Exception e)
+            {
+                _log.Error("Reload callback failed for " + _filePath + ": " + e.Message, e);
+            }
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -1,0 +1,538 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace Common.HardwareSupport.Calibration
+{
+    // Shared base for per-gauge calibration configs authored by the SimLinkup
+    // Profile Editor. Each gauge HSM that opts in derives a thin subclass with
+    // [XmlRoot(nameof(<TheModule>))] so the on-disk root element name matches
+    // the gauge HSM class name (matches the existing Simtek100285 / Simtek100294
+    // precedent — and what the editor writes).
+    //
+    // Schema (matches the editor's gauge-config-io.js round-trip):
+    //   <YourModuleName>
+    //     <Channels>
+    //       <Channel id="<HSM-port-id>">
+    //         <Transform kind="piecewise|linear|resolver|multi_resolver|cross_coupled">
+    //           <Breakpoints>             <!-- piecewise only -->
+    //             <Point input="..." volts="..."/>
+    //             ...
+    //           </Breakpoints>
+    //         </Transform>
+    //         <ZeroTrimVolts>0</ZeroTrimVolts>
+    //         <GainTrim>1</GainTrim>
+    //         <CoupledTo>...</CoupledTo>  <!-- cross_coupled only, optional -->
+    //       </Channel>
+    //     </Channels>
+    //   </YourModuleName>
+    //
+    // Today only the 'piecewise' kind is honoured by SimLinkup's gauge HSMs;
+    // the others round-trip safely so files survive future schema growth.
+    [Serializable]
+    public class GaugeCalibrationConfig
+    {
+        [XmlArray("Channels")]
+        [XmlArrayItem("Channel")]
+        public GaugeChannelConfig[] Channels { get; set; }
+
+        // Set by GetInstances after Load() so the gauge HSM's FileSystemWatcher
+        // knows which file to watch for hot-reload. [XmlIgnore] keeps it out of
+        // the round-trip (matches the ArduinoSeatHardwareSupportModuleConfig
+        // precedent).
+        [XmlIgnore]
+        public string FilePath { get; set; }
+
+        // Find a channel by its HSM port Id. Returns null when not present —
+        // gauge HSMs treat that as "no override; use hardcoded behaviour."
+        public GaugeChannelConfig FindChannel(string id)
+        {
+            if (Channels == null || string.IsNullOrEmpty(id)) return null;
+            return Channels.FirstOrDefault(c => c != null && c.Id == id);
+        }
+
+        // Generic loader. The caller passes T = derived per-gauge subclass and
+        // gets a strongly-typed result back. Safe to call when the file is
+        // absent — returns null in that case (callers fall back to hardcoded
+        // behaviour, matching the 10-0285 / 10-0294 precedent).
+        //
+        // Hot-reload-safe: this loader is what every editor-authored gauge
+        // config flows through, both at SimLinkup startup AND on every
+        // FileSystemWatcher Changed event. The watcher path races the
+        // editor's writer — the SimLinkup Profile Editor saves via Node's
+        // fs.writeFileSync, which on Windows triggers Changed events both
+        // when the file is truncated (size 0, XmlSerializer fails because
+        // the document is empty) AND when content is fully written. The
+        // first event arrives mid-write; without retries the watcher's
+        // change handler bails on it and the dedup mtime check skips
+        // subsequent events because LastWriteTime didn't change between
+        // truncate and write-complete on the same save. We close that
+        // race two ways:
+        //   1. Open the file with FileShare.ReadWrite so a writer holding
+        //      the file with default sharing doesn't lock us out
+        //      ("being used by another process" IOException).
+        //   2. Retry on transient failures (IOException + the
+        //      InvalidOperationException XmlSerializer throws on partial
+        //      documents) — 6 attempts × 50ms = ~300ms total, which
+        //      comfortably covers Node's writeFileSync window.
+        //
+        // Startup reads (no concurrent writer) hit the first attempt and
+        // return immediately, so this is free for the common case.
+        public static T Load<T>(string filePath) where T : GaugeCalibrationConfig
+        {
+            return Load<T>(filePath, attempts: 6, delayMs: 50);
+        }
+
+        public static T Load<T>(string filePath, int attempts, int delayMs) where T : GaugeCalibrationConfig
+        {
+            if (filePath == null) throw new ArgumentNullException("filePath");
+            if (!System.IO.File.Exists(filePath)) return default(T);
+            if (attempts < 1) attempts = 1;
+            Exception last = null;
+            var serializer = new XmlSerializer(typeof(T));
+            for (var i = 0; i < attempts; i++)
+            {
+                try
+                {
+                    using (var fs = new System.IO.FileStream(
+                        filePath,
+                        System.IO.FileMode.Open,
+                        System.IO.FileAccess.Read,
+                        System.IO.FileShare.ReadWrite))
+                    {
+                        return (T)serializer.Deserialize(fs);
+                    }
+                }
+                catch (System.IO.IOException e)
+                {
+                    last = e;  // editor's writer still holds the file — retry
+                }
+                catch (System.InvalidOperationException e)
+                {
+                    last = e;  // XmlSerializer hit a partial / empty file — retry
+                }
+                if (i + 1 < attempts && delayMs > 0)
+                {
+                    System.Threading.Thread.Sleep(delayMs);
+                }
+            }
+            // All retries exhausted; surface the last error so the caller's
+            // catch (every change-handler we've written) logs it.
+            if (last != null) throw last;
+            return default(T);
+        }
+
+        // Mirror of Save in the existing Simtek100285HardwareSupportModuleConfig
+        // precedent. Not used by SimLinkup itself today (the editor authors the
+        // file); included for symmetry and potential future round-trip tooling.
+        public void Save(string filePath)
+        {
+            Common.Serialization.Util.SerializeToXmlFile(this, filePath);
+        }
+    }
+
+    // Per-channel record. Distinguished by `Id` (matches the gauge HSM port
+    // signal Id, e.g. "100207_RPM_To_Instrument").
+    [Serializable]
+    public class GaugeChannelConfig
+    {
+        // The HSM output port Id this channel calibrates. Required.
+        [XmlAttribute("id")]
+        public string Id { get; set; }
+
+        // Transform record describing how input → volts is computed.
+        // Optional: when absent (or kind is unknown), gauge HSMs fall back to
+        // their hardcoded behaviour and still apply ZeroTrim/Gain on top.
+        [XmlElement("Transform")]
+        public GaugeTransformConfig Transform { get; set; }
+
+        // Per-channel zero-volt offset added to the computed transform output
+        // before the ±10 V clamp. 0 by default. Useful for trimming the gauge's
+        // physical needle zero point without changing the breakpoint table.
+        // Implemented as a nullable so we can distinguish "explicitly 0 in
+        // file" from "absent in file"; both behave the same way at runtime
+        // (additive offset of 0 is a no-op), but this lets future tooling
+        // tell the difference.
+        [XmlElement("ZeroTrimVolts")]
+        public double? ZeroTrimVolts { get; set; }
+
+        // Per-channel gain multiplier applied to the transform output before
+        // the ZeroTrim. 1.0 by default (unity). Useful for trimming full-scale
+        // span without re-tabulating breakpoints. Same nullable semantics as
+        // ZeroTrimVolts.
+        [XmlElement("GainTrim")]
+        public double? GainTrim { get; set; }
+
+        // Names another channel this one is computed from (cross_coupled).
+        // Round-trip-only today — SimLinkup's gauge HSMs don't yet act on it.
+        [XmlElement("CoupledTo")]
+        public string CoupledTo { get; set; }
+
+        // For digital_invert channels: whether the digital output is the
+        // logical inverse of the input. Defaults to false when absent. The
+        // 10-1084 ADI OFF flag uses this — its input is "OFF Flag Visible
+        // (1=visible)" and output is "OFF Flag Hidden (1=hidden)".
+        [XmlElement("Invert")]
+        public bool? Invert { get; set; }
+
+        // Caged-rest behaviour for standby ADI resolver pairs (pitch / roll
+        // SIN side carries these on each pair). When the gauge's OFF flag
+        // input is TRUE, the gauge's gimbal is mechanically caged — the
+        // gyro is at rest at whatever orientation it was in when last spun
+        // down, which is effectively random per power-cycle. The HSM picks
+        // a random angle in [Min, Max] degrees ONCE at construction time
+        // and drives sin/cos × PeakVolts to that angle for as long as the
+        // OFF flag stays TRUE. When the OFF flag goes FALSE (gauge spun
+        // up + uncaged), the HSM reverts to the configured piecewise
+        // transform and follows the input normally.
+        //
+        // Opt-in via CagedRestEnabled. Defaults to disabled (false / null)
+        // so existing profiles keep their pre-feature behaviour: when the
+        // OFF flag is visible the HSM continues to follow pitch/roll
+        // input regardless. Users who want the random rest behaviour
+        // enable it per gauge in the editor's Calibration tab.
+        //
+        // Only honoured by HSMs that opt in at the C# level (today:
+        // 10-0335-01 and 10-1084 standby ADIs, on their pitch and roll
+        // SIN channels). Editor defaults: pitch ±20°, roll ±40°. Set
+        // both Min and Max to the same value for a fixed (non-random)
+        // rest angle.
+        [XmlElement("CagedRestEnabled")]
+        public bool? CagedRestEnabled { get; set; }
+
+        [XmlElement("CagedRestRangeMinDegrees")]
+        public double? CagedRestRangeMinDegrees { get; set; }
+
+        [XmlElement("CagedRestRangeMaxDegrees")]
+        public double? CagedRestRangeMaxDegrees { get; set; }
+
+        // Apply ZeroTrim + GainTrim to a computed voltage, then clamp to
+        // [outputMin, outputMax] — the gauge's real hardware safe envelope
+        // (e.g. Westin EPU is 0.1..2.0 V, not the universal ±10 V). Callers
+        // pass the matching output signal's MinValue/MaxValue. The output
+        // signal is the canonical source of truth for what voltage is safe
+        // to send to the physical gauge mechanism, so trim values that
+        // would push the output past those bounds get clipped at the
+        // boundary instead of damaging the hardware.
+        //
+        // Order: gain first, then offset, then per-gauge clamp (matches
+        // what users intuitively expect when they say "make full-scale 5%
+        // wider then nudge zero up by 0.1 V").
+        //
+        // If outputMin >= outputMax (degenerate / unset bounds), returns 0
+        // so the gauge is visibly dead instead of quietly damaged. An HSM
+        // that forgets to declare MinValue/MaxValue on its output signal
+        // gets noticed on day one of testing rather than later.
+        public double ApplyTrim(double volts, double outputMin, double outputMax)
+        {
+            if (!(outputMin < outputMax)) return 0;
+            var gain   = GainTrim.HasValue      ? GainTrim.Value      : 1.0;
+            var offset = ZeroTrimVolts.HasValue ? ZeroTrimVolts.Value : 0.0;
+            var v = volts * gain + offset;
+            if (v < outputMin) return outputMin;
+            if (v > outputMax) return outputMax;
+            return v;
+        }
+    }
+
+    [Serializable]
+    public class GaugeTransformConfig
+    {
+        // 'piecewise' | 'linear' | 'resolver' | 'multi_resolver' | 'cross_coupled'.
+        // 'piecewise', 'linear', and 'resolver' are honoured by gauge HSMs
+        // today; the others round-trip for forward compatibility.
+        [XmlAttribute("kind")]
+        public string Kind { get; set; }
+
+        // Resolver pairs: each gauge has TWO output channels (sin + cos) but
+        // they share one transform. To avoid duplicating the transform on
+        // disk, the SIN channel carries the full transform body (InputMin,
+        // InputMax, AngleMin/MaxDegrees, PeakVolts, BelowMinBehavior) and
+        // the COS channel carries an empty body with role="cos" plus a
+        // PartnerChannel attribute pointing to the SIN channel id. The HSM
+        // reads both channels but pulls transform parameters from whichever
+        // carries them (always the SIN side as the editor writes it).
+        //
+        // role: "sin" or "cos" — present only for kind="resolver".
+        [XmlAttribute("role")]
+        public string Role { get; set; }
+
+        // Channel id of the partner (sin↔cos) — only set when Role is "cos".
+        [XmlAttribute("partnerChannel")]
+        public string PartnerChannel { get; set; }
+
+        // Piecewise transform: ordered breakpoint table. Linear interpolation
+        // between adjacent points; below the first / above the last clamps.
+        [XmlArray("Breakpoints")]
+        [XmlArrayItem("Point")]
+        public GaugeBreakpoint[] Breakpoints { get; set; }
+
+        // Linear and resolver transforms: maps `InputMin → angleMin / -10 V`
+        // and `InputMax → angleMax / +10 V`, with hard clamps outside.
+        // Nullable so the round-trip distinguishes "absent in file" from
+        // "explicitly set to 0".
+        [XmlElement("InputMin")]
+        public double? InputMin { get; set; }
+
+        [XmlElement("InputMax")]
+        public double? InputMax { get; set; }
+
+        // Resolver-specific: angular sweep mapped to [InputMin, InputMax].
+        // Default sweep is 0..360° if absent.
+        [XmlElement("AngleMinDegrees")]
+        public double? AngleMinDegrees { get; set; }
+
+        [XmlElement("AngleMaxDegrees")]
+        public double? AngleMaxDegrees { get; set; }
+
+        // Resolver peak voltage: sin/cos × PeakVolts is the output. Defaults
+        // to 10 V when absent — matches the Simtek 10-1088 convention.
+        [XmlElement("PeakVolts")]
+        public double? PeakVolts { get; set; }
+
+        // Resolver: what to do when input falls below InputMin. "zero" sets
+        // both outputs to 0 V (rest position; what 10-1088 nozzle does).
+        // "clamp" projects at angleMin (continuous behaviour expected by e.g.
+        // compass-style gauges). Default "clamp" if absent.
+        [XmlElement("BelowMinBehavior")]
+        public string BelowMinBehavior { get; set; }
+
+        // Multi-turn resolver: number of input units per full sin/cos
+        // revolution. Used by altimeter-style gauges where the synchro
+        // wraps many times across the input range (10-1081 altimeter
+        // fine = 1000 ft/rev; 10-0285 altimeter fine = 4000 ft/rev,
+        // coarse = 100000 ft/rev). The runtime computes
+        //   angle = (input / unitsPerRevolution) × 360°
+        // then sin/cos × peakVolts. No InputMin/Max needed — the sweep
+        // is unbounded; sin/cos handle negative angles cleanly.
+        [XmlElement("UnitsPerRevolution")]
+        public double? UnitsPerRevolution { get; set; }
+    }
+
+    [Serializable]
+    public class GaugeBreakpoint
+    {
+        [XmlAttribute("input")]
+        public double Input { get; set; }
+
+        // For piecewise transforms whose output is in volts (32 of the 33
+        // calibratable gauges in the editor). Default is 0 V; the C# default
+        // of `double` is also 0, so a gauge config that uses `output=` for
+        // raw DAC counts won't accidentally pick up the wrong value here.
+        [XmlAttribute("volts")]
+        public double Volts { get; set; }
+
+        // For piecewise transforms whose output is in raw DAC counts rather
+        // than volts (Henkie F-16 fuel flow drives its 12-bit DAC directly
+        // over USB/PHCC, bypassing AnalogDevices). Editor writes
+        // <Point input="500" output="18"/> for these gauges. HSMs that drive
+        // a DAC directly read this; HSMs that drive AD channels read Volts.
+        [XmlAttribute("output")]
+        public double Output { get; set; }
+
+        // For piecewise_resolver transforms: reference angle (degrees) at
+        // this input. Used by ADI-style gauges where the synchro angle is a
+        // non-linear function of the sim input (e.g. ADI pitch — input
+        // pitch°, output reference angle that drives a sin/cos pair). The
+        // angle should be encoded MONOTONICALLY in the breakpoint table —
+        // values may exceed 360° to keep linear interpolation working
+        // across the 360°→0° wrap; the runtime applies % 360 before
+        // computing sin/cos.
+        [XmlAttribute("angle")]
+        public double Angle { get; set; }
+    }
+
+    // Pure helpers. Live on the config namespace so per-gauge HSMs only need
+    // one `using Common.HardwareSupport.Calibration;` to evaluate a config.
+    public static class GaugeTransform
+    {
+        // Linearly interpolate `input` across an ordered list of breakpoints.
+        // Below the first breakpoint clamps to the first volts; above the last
+        // clamps to the last volts (matches the C# if/else fallback shape used
+        // by every Simtek HSM today). Returns the clamped voltage in ±10 V
+        // (final clamp lives in ApplyTrim, but pre-clamping here protects
+        // against breakpoints the editor may have flagged amber but saved).
+        //
+        // O(n) scan — the largest breakpoint table is 43 entries (10-0194
+        // airspeed); per-tick gauge update is well below any real cost.
+        public static double EvaluatePiecewise(double input, GaugeBreakpoint[] breakpoints)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                // Defensive: malformed config falls back to 0 V. Caller should
+                // detect this via a separate "config valid?" check before
+                // routing to this helper, but if they don't, 0 V is the
+                // safest neutral output.
+                return 0;
+            }
+            if (input <= breakpoints[0].Input) return Clamp(breakpoints[0].Volts);
+            var last = breakpoints[breakpoints.Length - 1];
+            if (input >= last.Input) return Clamp(last.Volts);
+            for (var i = 1; i < breakpoints.Length; i++)
+            {
+                var hi = breakpoints[i];
+                if (input < hi.Input)
+                {
+                    var lo = breakpoints[i - 1];
+                    var span = hi.Input - lo.Input;
+                    if (span <= 0) return Clamp(lo.Volts);  // degenerate; pick the lower
+                    var t = (input - lo.Input) / span;
+                    return Clamp(lo.Volts + t * (hi.Volts - lo.Volts));
+                }
+            }
+            return Clamp(last.Volts);
+        }
+
+        // Linear range: maps inputMin → -10 V, inputMax → +10 V, with hard
+        // clamps outside the range. Defensive against degenerate ranges
+        // (inputMin >= inputMax — returns 0 V neutral). Used by linear-pattern
+        // gauges (EPU fuel, fuel quantity, cabin altimeter, etc.).
+        public static double EvaluateLinear(double input, double inputMin, double inputMax)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return 0;
+            if (input <= inputMin) return -10;
+            if (input >= inputMax) return  10;
+            var t = (input - inputMin) / span;
+            return Clamp(-10 + t * 20);
+        }
+
+        // Resolver pair: maps `input` linearly to an angle in
+        // [angleMinDegrees, angleMaxDegrees], then projects to (sin, cos) ×
+        // peakVolts. `belowMinBehavior` controls the underflow case:
+        //   "zero"  — both outputs at 0 V (rest position; nozzle uses this)
+        //   "clamp" — project at angleMin (continuous; default)
+        // Above InputMax always clamps to angleMax (matches the C# nozzle
+        // shape and is the only behaviour that makes sense for a bounded
+        // mechanical gauge — full-scale stop).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each (sin and cos windings calibrate separately).
+        public static double[] EvaluateResolver(
+            double input,
+            double inputMin, double inputMax,
+            double angleMinDegrees, double angleMaxDegrees,
+            double peakVolts,
+            string belowMinBehavior)
+        {
+            var span = inputMax - inputMin;
+            if (span <= 0) return new double[] { 0, 0 };
+            double angleDeg;
+            if (input < inputMin)
+            {
+                if (string.Equals(belowMinBehavior, "zero", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new double[] { 0, 0 };
+                }
+                angleDeg = angleMinDegrees;
+            }
+            else if (input > inputMax)
+            {
+                angleDeg = angleMaxDegrees;
+            }
+            else
+            {
+                var t = (input - inputMin) / span;
+                angleDeg = angleMinDegrees + t * (angleMaxDegrees - angleMinDegrees);
+            }
+            // Fully qualify System.Math — there's a Common.Math namespace in
+            // sibling projects that shadows the unqualified `Math` here even
+            // with `using System;` in scope (because Common.HardwareSupport.
+            // Calibration is in the same parent namespace tree).
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Multi-turn resolver: input → angle = (input / unitsPerRevolution)
+        // × 360°, then sin/cos × peakVolts. The synchro wraps cleanly across
+        // many revolutions (negative angles included) — sin/cos handle it
+        // mathematically without any modulo logic. Used by altimeter-style
+        // gauges (10-1081 fine = 1000 ft/rev; 10-0285 fine = 4000 ft/rev).
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each.
+        public static double[] EvaluateMultiTurnResolver(
+            double input,
+            double unitsPerRevolution,
+            double peakVolts)
+        {
+            if (unitsPerRevolution == 0) return new double[] { 0, 0 };
+            var revolutions = input / unitsPerRevolution;
+            var angleDeg = revolutions * 360.0;
+            var rad = angleDeg * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        // Piecewise-then-resolver: linearly interpolate `input` across the
+        // breakpoint table (where each Point's `Angle` is the reference
+        // angle in degrees), then project to (sin, cos) × peakVolts. Used
+        // by ADI-style gauges where the synchro angle is a non-linear
+        // function of the sim input (10-1084 pitch is the founding case).
+        //
+        // The angle table should be MONOTONICALLY increasing — values may
+        // exceed 360° to keep linear interpolation working across the
+        // 360°→0° wrap; this helper applies % 360 before sin/cos so the
+        // wrap is invisible to the synchro hardware.
+        //
+        // Returns [sinVolts, cosVolts]; caller applies per-channel ApplyTrim
+        // independently for each. Below the first breakpoint clamps to the
+        // first angle; above the last clamps to the last (matches the
+        // EvaluatePiecewise voltage-clamp shape).
+        public static double[] EvaluatePiecewiseResolver(
+            double input,
+            GaugeBreakpoint[] breakpoints,
+            double peakVolts)
+        {
+            if (breakpoints == null || breakpoints.Length < 2)
+            {
+                return new double[] { 0, 0 };
+            }
+            double angleDeg;
+            if (input <= breakpoints[0].Input)
+            {
+                angleDeg = breakpoints[0].Angle;
+            }
+            else
+            {
+                var last = breakpoints[breakpoints.Length - 1];
+                if (input >= last.Input)
+                {
+                    angleDeg = last.Angle;
+                }
+                else
+                {
+                    angleDeg = last.Angle;  // overwritten in the loop unless degenerate
+                    for (var i = 1; i < breakpoints.Length; i++)
+                    {
+                        var hi = breakpoints[i];
+                        if (input < hi.Input)
+                        {
+                            var lo = breakpoints[i - 1];
+                            var span = hi.Input - lo.Input;
+                            if (span <= 0) { angleDeg = lo.Angle; break; }
+                            var t = (input - lo.Input) / span;
+                            angleDeg = lo.Angle + t * (hi.Angle - lo.Angle);
+                            break;
+                        }
+                    }
+                }
+            }
+            var rad = (angleDeg % 360.0) * System.Math.PI / 180.0;
+            var sin = Clamp(peakVolts * System.Math.Sin(rad));
+            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            return new double[] { sin, cos };
+        }
+
+        private static double Clamp(double v)
+        {
+            if (v < -10) return -10;
+            if (v >  10) return  10;
+            return v;
+        }
+    }
+}

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -40,6 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
+    <Compile Include="Calibration\GaugeCalibrationConfig.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/Common/HardwareSupport/Common.HardwareSupport.csproj
+++ b/src/Common/HardwareSupport/Common.HardwareSupport.csproj
@@ -39,6 +39,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Calibration\ConfigFileReloadWatcher.cs" />
     <Compile Include="CompositeControl.cs" />
     <Compile Include="HardwareSupportModuleBase.cs" />
     <Compile Include="HardwareSupportModuleRegistry.cs" />

--- a/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowHardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowHardwareSupportModuleConfig.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Henk.FuelFlow
+{
+    // Unified-schema calibration config for the Henkie F-16 fuel flow
+    // indicator, authored by the SimLinkup Profile Editor.
+    //
+    // This file lives ALONGSIDE the legacy
+    // HenkieF16FuelFlowIndicator.config — it does NOT replace it. The
+    // legacy file continues to own everything that's not the calibration
+    // table (stator base angles, COM port, address, connection type,
+    // diagnostic LED mode, DIG_OUT initial values). The unified file
+    // owns just the input→DAC breakpoint table, in the editor's standard
+    // <Channels>/<Transform kind="piecewise"> shape.
+    //
+    // Why split?
+    //   - The editor's Calibration tab speaks the unified schema for
+    //     every gauge (32 gauges + this one). Trying to fold stator
+    //     angles + DIG_OUTs into the unified schema would pollute it
+    //     with Henk-specific fields the other 32 gauges don't need.
+    //   - The legacy file's identity/stator/DIG_OUT fields are settled
+    //     once on bench-up and rarely touched — leaving them in the
+    //     legacy file means hand-edits made before the editor knew
+    //     about this gauge are preserved verbatim.
+    //   - Keeping calibration in its own file makes hot-reload a
+    //     small, well-bounded operation: when the editor saves, only
+    //     the calibration file's mtime changes, so the gauge HSM's
+    //     FileSystemWatcher only re-evaluates the breakpoint table —
+    //     no need to reconnect serial ports or re-program stators.
+    //
+    // Filename: HenkieF16FuelFlowHardwareSupportModule.config (NO
+    // "Indicator" suffix, distinguishing it from the legacy
+    // HenkieF16FuelFlowIndicator.config). Root element name matches.
+    //
+    // Editor-side counterpart: src/js/gauges/henkie-fuelflow.js +
+    // src/js/gauge-config-io.js's GAUGE_CONFIG_FILENAME_OVERRIDES.
+    [Serializable]
+    [XmlRoot("HenkieF16FuelFlowHardwareSupportModule")]
+    public class HenkieF16FuelFlowHardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowIndicatorHardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowIndicatorHardwareSupportModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
 using System.IO;
@@ -31,15 +32,36 @@ namespace SimLinkup.HardwareSupport.Henk.FuelFlow
 
 
         private CalibrationPoint[] _calibrationData;
-        private HenkieF16FuelFlowIndicatorHardwareSupportModule (DeviceConfig deviceConfig)
+
+        // Paths stashed at construction so the FileSystemWatchers (started
+        // below) can reload calibration when either file changes.
+        // _legacyConfigPath: HenkieF16FuelFlowIndicator.config (always present
+        // when this HSM instantiates — that's where stator angles + DIG_OUTs
+        // come from).
+        // _unifiedConfigPath: HenkieF16FuelFlowHardwareSupportModule.config
+        // (may not exist yet — the editor creates it the first time the user
+        // saves a calibration. The watcher uses Path+Filter so it fires even
+        // for file CREATE events).
+        private string _legacyConfigPath;
+        private string _unifiedConfigPath;
+        private ConfigFileReloadWatcher _legacyConfigWatcher;
+        private ConfigFileReloadWatcher _unifiedConfigWatcher;
+
+        private HenkieF16FuelFlowIndicatorHardwareSupportModule (
+            DeviceConfig deviceConfig,
+            string legacyConfigPath,
+            string unifiedConfigPath)
         {
             _deviceConfig = deviceConfig;
+            _legacyConfigPath = legacyConfigPath;
+            _unifiedConfigPath = unifiedConfigPath;
             if (_deviceConfig != null)
             {
                 ConfigureDevice();
                 CreateInputSignals();
                 CreateOutputSignals();
                 RegisterForEvents();
+                StartConfigWatchers();
             }
 
         }
@@ -96,13 +118,27 @@ namespace SimLinkup.HardwareSupport.Henk.FuelFlow
 
             try
             {
-                var hsmConfigFilePath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16FuelFlowIndicator.config");
-                var hsmConfig = HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                var legacyPath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16FuelFlowIndicator.config");
+                var unifiedPath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16FuelFlowHardwareSupportModule.config");
+                var hsmConfig = HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.Load(legacyPath);
+
+                // Try the unified-schema calibration file (authored by the
+                // SimLinkup Profile Editor). When present, its breakpoints
+                // override the legacy <CalibrationData> block. See
+                // HenkieF16FuelFlowHardwareSupportModuleConfig.cs for the
+                // rationale and round-trip contract.
+                var unifiedCalibration = TryLoadUnifiedCalibration(unifiedPath);
+
                 if (hsmConfig != null)
                 {
                     foreach (var deviceConfiguration in hsmConfig.Devices)
                     {
-                        var hsmInstance = new HenkieF16FuelFlowIndicatorHardwareSupportModule(deviceConfiguration);
+                        if (unifiedCalibration != null)
+                        {
+                            deviceConfiguration.CalibrationData = unifiedCalibration;
+                        }
+                        var hsmInstance = new HenkieF16FuelFlowIndicatorHardwareSupportModule(
+                            deviceConfiguration, legacyPath, unifiedPath);
                         toReturn.Add(hsmInstance);
                     }
                 }
@@ -113,6 +149,109 @@ namespace SimLinkup.HardwareSupport.Henk.FuelFlow
             }
 
             return toReturn.ToArray();
+        }
+
+        // Load + map the unified-schema calibration file's breakpoints onto
+        // the existing Henkie.Common.CalibrationPoint shape. Returns null
+        // when the file is absent, malformed, or doesn't contain the
+        // expected channel — in any of those cases the caller falls back
+        // to whatever's already on `deviceConfiguration.CalibrationData`
+        // (typically the legacy <CalibrationData> block).
+        private static CalibrationPoint[] TryLoadUnifiedCalibration(string unifiedPath)
+        {
+            try
+            {
+                if (!File.Exists(unifiedPath)) return null;
+                var unifiedConfig = GaugeCalibrationConfig.Load<HenkieF16FuelFlowHardwareSupportModuleConfig>(unifiedPath);
+                if (unifiedConfig == null) return null;
+                // Synthetic channel id agreed with the editor
+                // (src/js/gauges/henkie-fuelflow.js). The id is a round-trip
+                // handle — not a real HSM port — so the editor and SimLinkup
+                // can name the calibration table without inventing extra
+                // signals on the gauge.
+                var ch = unifiedConfig.FindChannel("HenkieF16FuelFlow_FuelFlow_To_Indicator");
+                var bps = ch?.Transform?.Breakpoints;
+                if (bps == null || bps.Length < 2) return null;
+                // Editor writes <Point input="..." output="..."/> — both are
+                // raw doubles, no volts/DAC conversion needed.
+                var result = new CalibrationPoint[bps.Length];
+                for (var i = 0; i < bps.Length; i++)
+                {
+                    result[i] = new CalibrationPoint(bps[i].Input, bps[i].Output);
+                }
+                return result;
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Failed to load unified-schema calibration; falling back to legacy <CalibrationData>: " + e.Message);
+                return null;
+            }
+        }
+
+        // Watch both calibration files. Either changing triggers a reload of
+        // just the calibration table — we never re-touch device identity or
+        // stator angles at runtime (those would require disconnecting and
+        // re-programming the hardware, which is the wrong thing to do
+        // mid-flight). The watcher mirrors the pattern used by every other
+        // HSM the editor authored a config for (Lilbern, AMI, Astronautics,
+        // Simtek, …).
+        // Hot-reload setup. Two ConfigFileReloadWatchers — one per
+        // config file. Both invoke ReloadCalibration on change; the
+        // helper's internal mtime dedup keeps duplicate events from
+        // firing the reload twice. Unlike the per-watcher patterns
+        // we used to have, the helper handles file-not-yet-existing
+        // (it will fire Created when the editor first writes the
+        // unified file) and self-heals from Windows watcher orphan
+        // scenarios via periodic resubscribe.
+        private void StartConfigWatchers()
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_legacyConfigPath))
+                {
+                    _legacyConfigWatcher = new ConfigFileReloadWatcher(_legacyConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+            try
+            {
+                if (!string.IsNullOrEmpty(_unifiedConfigPath))
+                {
+                    _unifiedConfigWatcher = new ConfigFileReloadWatcher(_unifiedConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+        }
+
+        // Re-evaluate calibration without touching the live device connection.
+        // Preference: unified file if present (editor's source of truth);
+        // legacy file's <CalibrationData> otherwise.
+        private void ReloadCalibration()
+        {
+            CalibrationPoint[] next = null;
+            try
+            {
+                next = TryLoadUnifiedCalibration(_unifiedConfigPath);
+                if (next == null && !string.IsNullOrEmpty(_legacyConfigPath) && File.Exists(_legacyConfigPath))
+                {
+                    var legacy = HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.Load(_legacyConfigPath);
+                    var dev = legacy?.Devices?.FirstOrDefault(d =>
+                        d != null && string.Equals(d.Address, _deviceConfig?.Address, StringComparison.OrdinalIgnoreCase));
+                    if (dev?.CalibrationData != null && dev.CalibrationData.Length >= 2)
+                    {
+                        next = dev.CalibrationData;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Calibration reload failed; keeping previous table: " + e.Message);
+                return;
+            }
+            if (next != null && next.Length >= 2)
+            {
+                _calibrationData = next;
+            }
         }
 
         private static int ChannelNumber(OutputChannels outputChannel)
@@ -462,6 +601,16 @@ namespace SimLinkup.HardwareSupport.Henk.FuelFlow
                     UnregisterForEvents();
                     Common.Util.DisposeObject(_fuelFlowDeviceInterface);
                     Common.Util.DisposeObject(_renderer);
+                    if (_legacyConfigWatcher != null)
+                    {
+                        try { _legacyConfigWatcher.Dispose(); } catch { }
+                        _legacyConfigWatcher = null;
+                    }
+                    if (_unifiedConfigWatcher != null)
+                    {
+                        try { _unifiedConfigWatcher.Dispose(); } catch { }
+                        _unifiedConfigWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -139,6 +139,7 @@
     <Compile Include="HardwareSupport\Henk\ADI\HenkF16ADISupportBoardHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\HSI\Board1\HenkF16HSIBoard1HardwareSupportModule.cs" />


### PR DESCRIPTION
## Summary

Adds an optional second config file for the Henkie F-16 fuel flow indicator HSM, alongside the existing `HenkieF16FuelFlowIndicator.config`:

```
HenkieF16FuelFlowHardwareSupportModule.config
```

Schema follows the standard `<Channels>` / `<Transform kind="piecewise">` shape used by every editor-authored gauge config (PR #14). Fuel flow drives a 12-bit DAC directly over USB/PHCC (bypassing AnalogDevices), so breakpoints use raw DAC counts rather than volts. The unified schema already supports this — the editor writes `<Point input="..." output="..."/>` for this gauge family and `GaugeBreakpoint.Output` is read alongside `.Volts`.

## Behaviour

- **`HenkieF16FuelFlowHardwareSupportModuleConfig`** — thin subclass of `GaugeCalibrationConfig` with the matching `XmlRoot`. Empty file by default; populated by the SimLinkup Profile Editor.
- **`HenkieF16FuelFlowIndicatorHardwareSupportModule.GetInstances`** — loads the unified file when present and overrides the device's `CalibrationData` with its breakpoints. When absent, the legacy `<CalibrationData>` block in `HenkieF16FuelFlowIndicator.config` still wins. **No behaviour change for users who haven't adopted the editor.**
- **`ConfigFileReloadWatcher`** (PR #13) watches both files. Hot-reload refreshes only the calibration table; device identity / stator angles / DIG_OUTs are programmed once at startup and never re-touched at runtime.

## Why two files?

The legacy file continues to own everything that's not the calibration table (`Address`, `COMPort`, `ConnectionType`, `StatorBaseAngles`, `OutputChannelsConfig`, `DiagnosticLEDMode`). Two files coexist deliberately — the legacy file ships with bench-calibrated factory defaults that aren't safe for the editor to overwrite without informed consent, and splitting the calibration table out lets the editor own just the pair of curves it understands while leaving everything else to the technician who set up the board.

## Stacked on

This PR is **stacked on PRs #13 (ConfigFileReloadWatcher) and #14 (GaugeCalibrationConfig)**. GitHub shows their commits in the diff because cross-repo PRs can't use a fork branch as the base. Merging order: #13 → #14 → this.

If you'd prefer to review only this PR's net change, the FuelFlow-only diff is the last commit on the branch (`8111d72`).

## Test plan

- [x] Builds clean off `pr/gauge-calibration-config`
- [x] Profile WITH editor-authored `HenkieF16FuelFlowHardwareSupportModule.config` — calibration table comes from the unified file
- [x] Profile WITHOUT the unified file (legacy users) — calibration table comes from the legacy `HenkieF16FuelFlowIndicator.config`, no behaviour change
- [x] Hot-reload — saving a new calibration from the editor takes effect within ~300ms (covered by PR #14's `Load<T>` retry path)
- [x] Device identity / stator angles / DIG_OUTs untouched on hot-reload (only the calibration table is re-applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)