### PR TITLE
GaugeCalibrationConfig: drop hardcoded ±10 V clamp from evaluators

### DIFF
--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -360,15 +360,25 @@ namespace Common.HardwareSupport.Calibration
         {
             if (breakpoints == null || breakpoints.Length < 2)
             {
-                // Defensive: malformed config falls back to 0 V. Caller should
+                // Defensive: malformed config falls back to 0. Caller should
                 // detect this via a separate "config valid?" check before
-                // routing to this helper, but if they don't, 0 V is the
-                // safest neutral output.
+                // routing to this helper, but if they don't, 0 is the
+                // safest neutral output for both volts-based gauges
+                // (= 0 V) and DAC-count gauges (= rest position).
                 return 0;
             }
-            if (input <= breakpoints[0].Input) return Clamp(breakpoints[0].Volts);
+            // No clamping here — the per-channel safe envelope lives on the
+            // output signal's MinValue/MaxValue and is enforced by ApplyTrim
+            // at the HSM boundary. Earlier versions of this helper hardcoded
+            // a ±10 V clamp; that was Simtek-specific (Simteks drive AD
+            // channels at ±10 V) and silently broke any gauge whose output
+            // range wasn't ±10 V — Henk F-16 ADI Support Board's pitch
+            // channel runs 140..700 (DAC counts), well outside ±10. Letting
+            // the math run and clamping at the per-channel boundary is the
+            // correct, gauge-agnostic shape.
+            if (input <= breakpoints[0].Input) return breakpoints[0].Volts;
             var last = breakpoints[breakpoints.Length - 1];
-            if (input >= last.Input) return Clamp(last.Volts);
+            if (input >= last.Input) return last.Volts;
             for (var i = 1; i < breakpoints.Length; i++)
             {
                 var hi = breakpoints[i];
@@ -376,26 +386,12 @@ namespace Common.HardwareSupport.Calibration
                 {
                     var lo = breakpoints[i - 1];
                     var span = hi.Input - lo.Input;
-                    if (span <= 0) return Clamp(lo.Volts);  // degenerate; pick the lower
+                    if (span <= 0) return lo.Volts;  // degenerate; pick the lower
                     var t = (input - lo.Input) / span;
-                    return Clamp(lo.Volts + t * (hi.Volts - lo.Volts));
+                    return lo.Volts + t * (hi.Volts - lo.Volts);
                 }
             }
-            return Clamp(last.Volts);
-        }
-
-        // Linear range: maps inputMin → -10 V, inputMax → +10 V, with hard
-        // clamps outside the range. Defensive against degenerate ranges
-        // (inputMin >= inputMax — returns 0 V neutral). Used by linear-pattern
-        // gauges (EPU fuel, fuel quantity, cabin altimeter, etc.).
-        public static double EvaluateLinear(double input, double inputMin, double inputMax)
-        {
-            var span = inputMax - inputMin;
-            if (span <= 0) return 0;
-            if (input <= inputMin) return -10;
-            if (input >= inputMax) return  10;
-            var t = (input - inputMin) / span;
-            return Clamp(-10 + t * 20);
+            return last.Volts;
         }
 
         // Resolver pair: maps `input` linearly to an angle in
@@ -441,8 +437,10 @@ namespace Common.HardwareSupport.Calibration
             // with `using System;` in scope (because Common.HardwareSupport.
             // Calibration is in the same parent namespace tree).
             var rad = angleDeg * System.Math.PI / 180.0;
-            var sin = Clamp(peakVolts * System.Math.Sin(rad));
-            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            // No clamping here — see EvaluatePiecewise comment. ApplyTrim
+            // at the HSM boundary owns the per-channel safe envelope.
+            var sin = peakVolts * System.Math.Sin(rad);
+            var cos = peakVolts * System.Math.Cos(rad);
             return new double[] { sin, cos };
         }
 
@@ -463,8 +461,10 @@ namespace Common.HardwareSupport.Calibration
             var revolutions = input / unitsPerRevolution;
             var angleDeg = revolutions * 360.0;
             var rad = angleDeg * System.Math.PI / 180.0;
-            var sin = Clamp(peakVolts * System.Math.Sin(rad));
-            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            // No clamping here — see EvaluatePiecewise comment. ApplyTrim
+            // at the HSM boundary owns the per-channel safe envelope.
+            var sin = peakVolts * System.Math.Sin(rad);
+            var cos = peakVolts * System.Math.Cos(rad);
             return new double[] { sin, cos };
         }
 
@@ -523,16 +523,11 @@ namespace Common.HardwareSupport.Calibration
                 }
             }
             var rad = (angleDeg % 360.0) * System.Math.PI / 180.0;
-            var sin = Clamp(peakVolts * System.Math.Sin(rad));
-            var cos = Clamp(peakVolts * System.Math.Cos(rad));
+            // No clamping here — see EvaluatePiecewise comment. ApplyTrim
+            // at the HSM boundary owns the per-channel safe envelope.
+            var sin = peakVolts * System.Math.Sin(rad);
+            var cos = peakVolts * System.Math.Cos(rad);
             return new double[] { sin, cos };
-        }
-
-        private static double Clamp(double v)
-        {
-            if (v < -10) return -10;
-            if (v >  10) return  10;
-            return v;
         }
     }
 }


### PR DESCRIPTION
## Summary

The evaluators in `GaugeTransform` (`EvaluatePiecewise` + the three resolver-family helpers) all baked a ±10 V hard clamp via a private `Clamp` helper. That was a Simtek-shaped assumption: Simteks drive AnalogDevices DAC channels at ±10 V, so the clamp matched their output signal range and was invisible.

For any gauge whose output range is **not** ±10 V the assumption silently breaks:

- Henk F-16 ADI Support Board's pitch channel runs **140..700** (DAC counts).
- Westin EPU runs **0.1..2.0** (volts).
- And so on.

Without this fix, calibrating those gauges against the unified schema would clip the breakpoint table outputs to ±10 V before the per-channel `ApplyTrim` could enforce the real envelope.

## The right design

The HSM is the source of truth for each channel's safe envelope — it sets the output signal's `MinValue` and `MaxValue` at construction based on what the physical hardware will accept, and `ApplyTrim` enforces those bounds at the HSM boundary. The schema-level evaluators have no business second-guessing per-gauge ranges.

## Changes

- `EvaluatePiecewise` — drop `Clamp` wrapper from all return sites.
- `EvaluateResolver` — drop `Clamp` from sin/cos.
- `EvaluateMultiTurnResolver` — drop `Clamp` from sin/cos.
- `EvaluatePiecewiseResolver` — drop `Clamp` from sin/cos.
- Delete the now-unused `Clamp` helper.
- Delete `EvaluateLinear`: zero callers in the tree, and its design ("map input range to ±10 V") is itself the same Simtek-coupling bug under a different name. If a future linear-pattern gauge wants linear math, it should be re-introduced with a gauge-agnostic shape.

## Net effect on existing callers

**Zero behaviour change.** All 24 callers of `EvaluatePiecewise` (Simtek + AMI + Astronautics + Lilbern + Westin) feed the result through `ApplyTrim(value, signal.MinValue, signal.MaxValue)`, which clips at the per-channel safe envelope just as before. The math may briefly produce a value past ±10 V before `ApplyTrim` clips it back — same final output. For Simteks (signal range = ±10 V) that's a no-op; for non-Simtek gauges with different envelopes the clamp now actually matches the hardware.

## Test plan

- [x] Builds clean off `master` (Debug + Release)
- [x] All 24 existing `EvaluatePiecewise` callers compile without changes
- [x] Calibration round-trip on a Simtek (pitch ±10 V) — same output as before
- [ ] Calibration on a non-Simtek-range gauge (Henk F-16 ADI in upcoming PR) — output now respects the channel's actual signal range

## Why send this separately

This change unblocks the Henk F-16 ADI Support Board calibration PR (next), which authors a config with output values up to 700 — well outside ±10. Sending the fix as its own PR keeps the surface area trivial (one file, mechanical clamp removal) and the Henk ADI PR can stack on top of it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)