### PR TITLE
Henk F-16 ADI Support Board: editor-authored calibration

### DIFF
--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -207,6 +207,23 @@ namespace Common.HardwareSupport.Calibration
         [XmlElement("CagedRestRangeMaxDegrees")]
         public double? CagedRestRangeMaxDegrees { get; set; }
 
+        // Output value driven by the HSM when this channel's "visible"
+        // gate is FALSE. Today only used by gauges with a digital
+        // visibility flag inhibiting an analog channel — Henk F-16 ADI
+        // Support Board's two command bars are the canonical example
+        // (when commandBarsVisible is low, the bar parks at a fixed
+        // off-screen position). Nullable: absent means "no hidden
+        // behaviour" and the channel is driven from its transform
+        // unconditionally.
+        //
+        // The HSM is the source of truth for which channels honour
+        // this — opt-in per channel in the HSM's Update*OutputValues
+        // method. The schema field is generic so any future
+        // flag-gated analog channel can use it without re-revving
+        // the file format.
+        [XmlElement("HiddenOutput")]
+        public double? HiddenOutput { get; set; }
+
         // Apply ZeroTrim + GainTrim to a computed voltage, then clamp to
         // [outputMin, outputMax] — the gauge's real hardware safe envelope
         // (e.g. Westin EPU is 0.1..2.0 V, not the universal ±10 V). Callers

--- a/src/SimLinkup/HardwareSupport/Henk/ADI/HenkF16ADISupportBoardHardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/ADI/HenkF16ADISupportBoardHardwareSupportModule.cs
@@ -1,17 +1,36 @@
 ﻿using System;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
+using log4net;
 
 namespace SimLinkup.HardwareSupport.Henk.ADI
 {
     //Henk F-16 ADI Support Board for ARU-50/A Primary ADI
     public class HenkF16ADISupportBoardHardwareSupportModule : HardwareSupportModuleBase, IDisposable
     {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(HenkF16ADISupportBoardHardwareSupportModule));
+
         private const float GLIDESLOPE_DEVIATION_LIMIT_DEGREES = 1.0F;
         private const float LOCALIZER_DEVIATION_LIMIT_DEGREES = 5.0F;
+
+        // Editor-authored calibration state. _config carries the loaded
+        // unified-schema file; the per-channel pointers below are non-null
+        // when the corresponding channel has a usable piecewise breakpoint
+        // table. Each Update*OutputValues consults its pointer and falls
+        // back to the hardcoded math when null. See
+        // HenkF16ADISupportBoardHardwareSupportModuleConfig for the schema.
+        private HenkF16ADISupportBoardHardwareSupportModuleConfig _config;
+        private GaugeChannelConfig _pitchCalibration;
+        private GaugeChannelConfig _rollCalibration;
+        private GaugeChannelConfig _horizontalCommandBarCalibration;
+        private GaugeChannelConfig _verticalCommandBarCalibration;
+        private GaugeChannelConfig _rateOfTurnCalibration;
+        private ConfigFileReloadWatcher _configWatcher;
 
         private readonly IADI _renderer = new LightningGauges.Renderers.F16.ADI();
         private DigitalSignal _auxFlagInputSignal;
@@ -61,13 +80,99 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         private AnalogSignal.AnalogSignalChangedEventHandler _verticalCommandBarInputSignalChangedEventHandler;
         private AnalogSignal _verticalCommandBarOutputSignal;
 
-        private HenkF16ADISupportBoardHardwareSupportModule()
+        // Public ctor takes the (optionally-null) config. Null = no editor
+        // override; the existing hardcoded math handles everything.
+        public HenkF16ADISupportBoardHardwareSupportModule(HenkF16ADISupportBoardHardwareSupportModuleConfig config)
         {
+            _config = config;
+            ResolveAllChannels(config);
             CreateInputSignals();
             CreateInputEventHandlers();
             CreateOutputSignals();
             SetInitialOutputValues();
             RegisterForInputEvents();
+            StartConfigWatcher();
+        }
+
+        // Resolve all five channel pointers in one pass. Each may end up
+        // null (no config / channel absent / channel not piecewise) — the
+        // per-update branches handle null individually with a fallback to
+        // the hardcoded math.
+        private void ResolveAllChannels(GaugeCalibrationConfig config)
+        {
+            _pitchCalibration                = ResolvePiecewiseChannel(config, "HenkF16ADISupportBoard_Pitch_To_SDI");
+            _rollCalibration                 = ResolvePiecewiseChannel(config, "HenkF16ADISupportBoard_Roll_To_SDI");
+            _horizontalCommandBarCalibration = ResolvePiecewiseChannel(config, "HenkF16ADISupportBoard_Horizontal_GS_Bar_To_SDI");
+            _verticalCommandBarCalibration   = ResolvePiecewiseChannel(config, "HenkF16ADISupportBoard_Vertical_GS_Bar_To_SDI");
+            _rateOfTurnCalibration           = ResolvePiecewiseChannel(config, "HenkF16ADISupportBoard_Rate_Of_Turn_To_SDI");
+        }
+
+        // Pull the named channel out of the config IFF it carries a usable
+        // piecewise breakpoint table. Returns null otherwise so the caller's
+        // null-check covers both "no config file" and "config present but
+        // doesn't override this channel" with the same code path.
+        private static GaugeChannelConfig ResolvePiecewiseChannel(GaugeCalibrationConfig config, string channelId)
+        {
+            if (config == null) return null;
+            var ch = config.FindChannel(channelId);
+            if (ch != null
+                && ch.Transform != null
+                && ch.Transform.Kind == "piecewise"
+                && ch.Transform.Breakpoints != null
+                && ch.Transform.Breakpoints.Length >= 2)
+            {
+                return ch;
+            }
+            return null;
+        }
+
+        // Set up a ConfigFileReloadWatcher on the config file so editor
+        // saves take effect within a few seconds on the running SimLinkup.
+        // Skipped when no config was loaded (nothing to watch). The shared
+        // helper handles the unreliable bits — silent watcher orphaning
+        // under antivirus / OneDrive / SMB filter drivers, internal buffer
+        // overflow, mtime dedup — so this HSM just supplies the reload
+        // callback.
+        private void StartConfigWatcher()
+        {
+            if (_config == null || string.IsNullOrEmpty(_config.FilePath)) return;
+            try
+            {
+                _configWatcher = new ConfigFileReloadWatcher(_config.FilePath, ReloadConfig);
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+        }
+
+        // Reload the config and re-resolve channel pointers. Wrapped in a
+        // try/catch so a partial-write race (the watcher can fire mid-save)
+        // doesn't escape into the runtime — we just log and wait for the
+        // next change event with a complete file. Re-fires every Update*
+        // method at the end so the user sees the new calibration
+        // immediately, instead of waiting for the next sim tick.
+        private void ReloadConfig()
+        {
+            try
+            {
+                var configFile = _config != null ? _config.FilePath : null;
+                if (string.IsNullOrEmpty(configFile)) return;
+                var reloaded = GaugeCalibrationConfig.Load<HenkF16ADISupportBoardHardwareSupportModuleConfig>(configFile);
+                if (reloaded == null) return;
+                reloaded.FilePath = configFile;
+                _config = reloaded;
+                ResolveAllChannels(reloaded);
+                UpdatePitchOutputValues();
+                UpdateRollOutputValues();
+                UpdateHorizontalGSBarOutputValues();
+                UpdateVerticalGSBarOutputValues();
+                UpdateRateOfTurnOutputValues();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex.Message, ex);
+            }
         }
 
         public override AnalogSignal[] AnalogInputs => new[]
@@ -110,9 +215,30 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
             Dispose(false);
         }
 
+        // Try to load the optional editor-authored config file alongside
+        // the registry. Missing or malformed file → null config → HSM
+        // falls back to its hardcoded math (= pre-config behaviour).
         public static IHardwareSupportModule[] GetInstances()
         {
-            return new IHardwareSupportModule[] {new HenkF16ADISupportBoardHardwareSupportModule()};
+            HenkF16ADISupportBoardHardwareSupportModuleConfig hsmConfig = null;
+            try
+            {
+                var hsmConfigFilePath = Path.Combine(
+                    Util.CurrentMappingProfileDirectory,
+                    "HenkF16ADISupportBoardHardwareSupportModule.config");
+                hsmConfig = GaugeCalibrationConfig.Load<HenkF16ADISupportBoardHardwareSupportModuleConfig>(hsmConfigFilePath);
+                if (hsmConfig != null)
+                {
+                    // Stash the path on the config so the instance's
+                    // ConfigFileReloadWatcher knows which file to watch.
+                    hsmConfig.FilePath = hsmConfigFilePath;
+                }
+            }
+            catch (Exception e)
+            {
+                _log.Error(e.Message, e);
+            }
+            return new IHardwareSupportModule[] { new HenkF16ADISupportBoardHardwareSupportModule(hsmConfig) };
         }
 
         public override void Render(Graphics g, Rectangle destinationRectangle)
@@ -671,6 +797,11 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
                     UnregisterForInputEvents();
                     AbandonInputEventHandlers();
                     Common.Util.DisposeObject(_renderer);
+                    if (_configWatcher != null)
+                    {
+                        try { _configWatcher.Dispose(); } catch { }
+                        _configWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;
@@ -968,9 +1099,26 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         {
             if (_horizontalCommandBarInputSignal != null && _horizontalCommandBarOutputSignal != null)
             {
-                _horizontalCommandBarOutputSignal.State = _commandBarsVisibleInputSignal.State
-                    ? 0.5 + 0.5 * _horizontalCommandBarInputSignal.State
-                    : 1.0f;
+                // Hidden state when the visibility flag is low. Editor-
+                // authored HiddenOutput overrides the hardcoded 1.0 (the
+                // value that physically pushes the bar off-screen on
+                // bench-stock ADIs; some installations need a different
+                // park position).
+                if (!_commandBarsVisibleInputSignal.State)
+                {
+                    var hidden = _horizontalCommandBarCalibration?.HiddenOutput ?? 1.0;
+                    _horizontalCommandBarOutputSignal.State = _horizontalCommandBarCalibration != null
+                        ? _horizontalCommandBarCalibration.ApplyTrim(hidden, _horizontalCommandBarOutputSignal.MinValue, _horizontalCommandBarOutputSignal.MaxValue)
+                        : hidden;
+                    return;
+                }
+                if (_horizontalCommandBarCalibration != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(_horizontalCommandBarInputSignal.State, _horizontalCommandBarCalibration.Transform.Breakpoints);
+                    _horizontalCommandBarOutputSignal.State = _horizontalCommandBarCalibration.ApplyTrim(v, _horizontalCommandBarOutputSignal.MinValue, _horizontalCommandBarOutputSignal.MaxValue);
+                    return;
+                }
+                _horizontalCommandBarOutputSignal.State = 0.5 + 0.5 * _horizontalCommandBarInputSignal.State;
             }
         }
 
@@ -994,6 +1142,13 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         {
             if (_pitchInputSignal != null && _pitchOutputSignal != null)
             {
+                // Editor override: piecewise breakpoint table (input°, output DAC counts).
+                if (_pitchCalibration != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(_pitchInputSignal.CorrelatedState, _pitchCalibration.Transform.Breakpoints);
+                    _pitchOutputSignal.State = _pitchCalibration.ApplyTrim(v, _pitchOutputSignal.MinValue, _pitchOutputSignal.MaxValue);
+                    return;
+                }
                 _pitchOutputSignal.State = 424 + _pitchInputSignal.CorrelatedState / 90.000 * 255.000;
             }
         }
@@ -1010,6 +1165,13 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         {
             if (_rateOfTurnInputSignal != null && _rateOfTurnOutputSignal != null)
             {
+                // Editor override: piecewise breakpoint table (input -1..+1, output 0..1).
+                if (_rateOfTurnCalibration != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(_rateOfTurnInputSignal.State, _rateOfTurnCalibration.Transform.Breakpoints);
+                    _rateOfTurnOutputSignal.State = _rateOfTurnCalibration.ApplyTrim(v, _rateOfTurnOutputSignal.MinValue, _rateOfTurnOutputSignal.MaxValue);
+                    return;
+                }
                 _rateOfTurnOutputSignal.State = (_rateOfTurnInputSignal.State + 1.000) / 2.000;
             }
         }
@@ -1018,6 +1180,13 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         {
             if (_rollInputSignal != null && _rollOutputSignal != null)
             {
+                // Editor override: piecewise breakpoint table (input°, output DAC counts).
+                if (_rollCalibration != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(_rollInputSignal.CorrelatedState, _rollCalibration.Transform.Breakpoints);
+                    _rollOutputSignal.State = _rollCalibration.ApplyTrim(v, _rollOutputSignal.MinValue, _rollOutputSignal.MaxValue);
+                    return;
+                }
                 _rollOutputSignal.State = 512.000 + _rollInputSignal.CorrelatedState / 180.000 * 512.000;
             }
         }
@@ -1026,9 +1195,23 @@ namespace SimLinkup.HardwareSupport.Henk.ADI
         {
             if (_verticalCommandBarInputSignal != null && _verticalCommandBarOutputSignal != null)
             {
-                _verticalCommandBarOutputSignal.State = _commandBarsVisibleInputSignal.State
-                    ? 1.00 - (0.5 + 0.5 * _verticalCommandBarInputSignal.State)
-                    : 0.0f;
+                // Hidden state when the visibility flag is low. Editor-
+                // authored HiddenOutput overrides the hardcoded 0.0.
+                if (!_commandBarsVisibleInputSignal.State)
+                {
+                    var hidden = _verticalCommandBarCalibration?.HiddenOutput ?? 0.0;
+                    _verticalCommandBarOutputSignal.State = _verticalCommandBarCalibration != null
+                        ? _verticalCommandBarCalibration.ApplyTrim(hidden, _verticalCommandBarOutputSignal.MinValue, _verticalCommandBarOutputSignal.MaxValue)
+                        : hidden;
+                    return;
+                }
+                if (_verticalCommandBarCalibration != null)
+                {
+                    var v = GaugeTransform.EvaluatePiecewise(_verticalCommandBarInputSignal.State, _verticalCommandBarCalibration.Transform.Breakpoints);
+                    _verticalCommandBarOutputSignal.State = _verticalCommandBarCalibration.ApplyTrim(v, _verticalCommandBarOutputSignal.MinValue, _verticalCommandBarOutputSignal.MaxValue);
+                    return;
+                }
+                _verticalCommandBarOutputSignal.State = 1.00 - (0.5 + 0.5 * _verticalCommandBarInputSignal.State);
             }
         }
 

--- a/src/SimLinkup/HardwareSupport/Henk/ADI/HenkF16ADISupportBoardHardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/ADI/HenkF16ADISupportBoardHardwareSupportModuleConfig.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Henk.ADI
+{
+    // Unified-schema calibration config for the Henk F-16 ADI Support
+    // Board (ARU-50/A primary ADI), authored by the SimLinkup Profile
+    // Editor.
+    //
+    // Unlike most other gauge HSMs that ship with a legacy config file
+    // alongside the unified one, this board had NO config file before
+    // editor support — its calibration was entirely hardcoded constants
+    // in the HSM. This config is therefore the sole source of editor-
+    // authored overrides; absent file = HSM uses hardcoded defaults
+    // (no behaviour change for users who haven't adopted the editor).
+    //
+    // Five overridable channels, all piecewise-table:
+    //   - HenkF16ADISupportBoard_Pitch_To_SDI            (input ±90°,  output 169..679)
+    //   - HenkF16ADISupportBoard_Roll_To_SDI             (input ±180°, output 0..1024)
+    //   - HenkF16ADISupportBoard_Horizontal_GS_Bar_To_SDI (input ±1,    output 0..1)
+    //   - HenkF16ADISupportBoard_Vertical_GS_Bar_To_SDI   (input ±1,    output 0..1)
+    //   - HenkF16ADISupportBoard_Rate_Of_Turn_To_SDI     (input ±1,    output 0..1)
+    //
+    // The two command-bar channels also honour the unified schema's
+    // HiddenOutput field — when the board's commandBarsVisible digital
+    // input is FALSE, the bar is parked at HiddenOutput rather than
+    // being driven from its breakpoint table. Defaults: 1.0 horizontal,
+    // 0.0 vertical (matches the hardcoded values).
+    //
+    // Filename: HenkF16ADISupportBoardHardwareSupportModule.config.
+    // Root element name matches.
+    //
+    // Editor-side counterpart: src/js/gauges/henk-adi.js +
+    // src/js/gauge-config-io.js's GAUGE_CONFIG_FILENAME_OVERRIDES.
+    [Serializable]
+    [XmlRoot("HenkF16ADISupportBoardHardwareSupportModule")]
+    public class HenkF16ADISupportBoardHardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+    }
+}

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -147,6 +147,7 @@
     <Compile Include="HardwareSupport\Gould\GouldHS070D51341HardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Gould\GouldHS070D51341HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\ADI\HenkF16ADISupportBoardHardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Henk\ADI\HenkF16ADISupportBoardHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowHardwareSupportModuleConfig.cs" />


### PR DESCRIPTION
## Summary

Wires the Henk F-16 ADI Support Board (ARU-50/A primary ADI) into the unified gauge-config schema so users can calibrate it from the SimLinkup Profile Editor's Calibration tab. Five overridable channels:

| Channel | Input range | Output range |
|---|---|---|
| `HenkF16ADISupportBoard_Pitch_To_SDI` | ±90° | 169..679 (DAC counts) |
| `HenkF16ADISupportBoard_Roll_To_SDI` | ±180° | 0..1024 (DAC counts) |
| `HenkF16ADISupportBoard_Horizontal_GS_Bar_To_SDI` | ±1 | 0..1 |
| `HenkF16ADISupportBoard_Vertical_GS_Bar_To_SDI` | ±1 | 0..1 |
| `HenkF16ADISupportBoard_Rate_Of_Turn_To_SDI` | ±1 | 0..1 |

All five use piecewise breakpoint tables. Defaults match the hardcoded math currently in the HSM, so a profile without a config file (or one that ships defaults) sees zero behaviour change.

## New schema field: `HiddenOutput`

The two command-bar channels also honour a new optional field on `GaugeChannelConfig`:

```csharp
[XmlElement("HiddenOutput")]
public double? HiddenOutput { get; set; }
```

Used when the board's `commandBarsVisible` digital input is **FALSE** — the bar parks at `HiddenOutput` rather than being driven from its breakpoint table. Defaults: `1.0` horizontal, `0.0` vertical (matches the C# hardcoded park values some bench-stock ADIs use to push the bar off-screen). Users override per-board if their ADI's mechanical park position differs.

The schema field is intentionally generic so any future flag-gated analog channel can use it without re-revving the file format.

## HSM changes

- Private constructor → public, accepts `(optionally-null)` config.
- `GetInstances` loads `HenkF16ADISupportBoardHardwareSupportModule.config` via `GaugeCalibrationConfig.Load<>()`. Missing/malformed file → `null` config → all per-channel resolutions return `null` → all `Update*OutputValues` fall through to the hardcoded math (= pre-config behaviour).
- `ConfigFileReloadWatcher` started/disposed alongside the instance for hot-reload (saves take effect within seconds; `ReloadConfig` re-fires every `Update*` method so the user sees new values without waiting for the next sim tick).
- Each `Update*OutputValues` consults its per-channel pointer; when set, evaluates the breakpoint table and applies per-channel `ApplyTrim` with the output signal's `MinValue`/`MaxValue` (which declare the safe envelope, e.g. pitch = 140..700, roll = 0..1023).

## New file

`src/SimLinkup/HardwareSupport/Henk/ADI/HenkF16ADISupportBoardHardwareSupportModuleConfig.cs` — thin subclass of `GaugeCalibrationConfig` with the matching `XmlRoot`. The board had no config file before this PR; this is the sole source of editor-authored overrides.

## Stacked on

This PR depends on **#24** (drop hardcoded ±10 V clamp from evaluators) being in `master`. Without it, the breakpoint table outputs (which exceed ±10 for pitch and roll) would be clipped to ±10 by the schema-level evaluator before `ApplyTrim` could enforce the actual per-channel envelope.

## Test plan

- [x] Builds clean off `master` (Debug)
- [x] Profile WITHOUT the new `.config` file: HSM behaves exactly as today (same hardcoded math)
- [ ] Profile WITH a default `.config` file (round-trip from editor save): outputs identical to hardcoded path
- [ ] Edit a pitch breakpoint; reload; HSM picks up the new value mid-flight (hot reload)
- [ ] Toggle `commandBarsVisible` low; horizontal bar output goes to the configured `HiddenOutput`. Edit `HiddenOutput` from `1.0` to `0.95`; reload; bar moves to `0.95`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)