### PR TITLE
Henk F-16 HSI Boards 1 & 2: editor-authored calibration

### DIFF
--- a/src/SimLinkup/HardwareSupport/Henk/HSI/Board1/HenkF16HSIBoard1CalibrationConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/HSI/Board1/HenkF16HSIBoard1CalibrationConfig.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Henk.HSI.Board1
+{
+    // Unified-schema calibration config for the Henk F-16 HSI Board 1,
+    // authored by the SimLinkup Profile Editor.
+    //
+    // This file lives ALONGSIDE the legacy
+    // HenkF16HSIBoard1HardwareSupportModule.config — it does NOT replace
+    // it. The legacy file continues to own everything that's not the
+    // calibration tables (Address, COMPort, ConnectionType, stator
+    // offsets, DIG_OUT initial values). The unified file owns just the
+    // five input→DAC breakpoint tables, in the editor's standard
+    // <Channels>/<Transform kind="piecewise"> shape.
+    //
+    // Why split?
+    //   - The editor's Calibration tab speaks the unified schema for
+    //     every gauge. Folding stator offsets / DIG_OUTs into the
+    //     unified schema would pollute it with Henk-specific fields
+    //     the other gauges don't need.
+    //   - The legacy file's identity / stator / DIG_OUT fields are
+    //     settled once on bench-up and rarely touched — leaving them
+    //     in the legacy file means hand-edits made before the editor
+    //     knew about this gauge are preserved verbatim.
+    //
+    // Filename: HenkF16HSIBoard1Calibration.config — distinct from the
+    // legacy HenkF16HSIBoard1HardwareSupportModule.config to avoid
+    // the editor's filename auto-derivation overwriting the legacy file.
+    // The matching editor-side filename override lives in
+    // src/js/gauge-config-io.js's GAUGE_CONFIG_FILENAME_OVERRIDES.
+    //
+    // Five overridable channels (all piecewise tables driving DAC counts
+    // to synchro stators on the indicator):
+    //   - Henk_F16_HSI_Board1_Magnetic_Heading_To_Instrument  (0..360°  → 0..1023)
+    //   - Henk_F16_HSI_Board1_Bearing_To_Instrument           (0..360°  → 0..1023)
+    //   - Henk_F16_HSI_Board1_Range_x100_To_Instrument        (0..10    → 0..1023)
+    //   - Henk_F16_HSI_Board1_Range_x10_To_Instrument         (0..10    → 0..1023)
+    //   - Henk_F16_HSI_Board1_Range_x1_To_Instrument          (0..10    → 0..1023)
+    //
+    // Editor-side counterpart: src/js/gauges/henk-hsi-board1.js +
+    // src/js/gauge-config-io.js's GAUGE_CONFIG_FILENAME_OVERRIDES.
+    [Serializable]
+    [XmlRoot("HenkF16HSIBoard1Calibration")]
+    public class HenkF16HSIBoard1CalibrationConfig : GaugeCalibrationConfig
+    {
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Henk/HSI/Board1/HenkF16HSIBoard1HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/HSI/Board1/HenkF16HSIBoard1HardwareSupportModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16.HSI;
 using Henkie.HSI.Board1;
@@ -57,15 +58,32 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board1
         private CalibrationPoint[] _rangeTensDigitCalibrationData;
         private CalibrationPoint[] _rangeHundredsDigitCalibrationData;
 
-        private HenkF16HSIBoard1HardwareSupportModule(DeviceConfig hsiBoard1DeviceConfig)
+        // Editor-authored calibration plumbing. Both files are watched —
+        // the legacy file (HenkF16HSIBoard1HardwareSupportModule.config)
+        // continues to own identity / stator offsets / DIG_OUTs; the
+        // unified file (HenkF16HSIBoard1Calibration.config) carries
+        // editor-authored breakpoint tables that, when present, override
+        // the per-channel CalibrationData arrays on the legacy device
+        // config. Hot-reload on either file re-runs ReloadCalibration
+        // without touching the live device connection. See
+        // HenkF16HSIBoard1CalibrationConfig.cs for the contract.
+        private string _legacyConfigPath;
+        private string _unifiedConfigPath;
+        private ConfigFileReloadWatcher _legacyConfigWatcher;
+        private ConfigFileReloadWatcher _unifiedConfigWatcher;
+
+        private HenkF16HSIBoard1HardwareSupportModule(DeviceConfig hsiBoard1DeviceConfig, string legacyConfigPath, string unifiedConfigPath)
         {
             _hsiBoard1DeviceConfig = hsiBoard1DeviceConfig;
+            _legacyConfigPath = legacyConfigPath;
+            _unifiedConfigPath = unifiedConfigPath;
             if (_hsiBoard1DeviceConfig != null)
             {
                 ConfigureDevice();
                 CreateInputSignals();
                 CreateOutputSignals();
                 RegisterForEvents();
+                StartConfigWatchers();
             }
         }
 
@@ -119,13 +137,26 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board1
 
             try
             {
-                var hsmConfigFilePath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard1HardwareSupportModule.config");
-                var hsmConfig = HenkieF16HSIBoard1HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                var legacyPath  = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard1HardwareSupportModule.config");
+                var unifiedPath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard1Calibration.config");
+                var hsmConfig = HenkieF16HSIBoard1HardwareSupportModuleConfig.Load(legacyPath);
+
+                // Try the unified-schema calibration file (authored by the
+                // SimLinkup Profile Editor). When present, its per-channel
+                // breakpoint tables override the legacy file's
+                // <*CalibrationData> blocks. See
+                // HenkF16HSIBoard1CalibrationConfig.cs for the rationale.
+                var unifiedOverrides = TryLoadUnifiedOverrides(unifiedPath);
+
                 if (hsmConfig != null)
                 {
                     foreach (var deviceConfiguration in hsmConfig.Devices)
                     {
-                        var hsmInstance = new HenkF16HSIBoard1HardwareSupportModule(deviceConfiguration);
+                        if (unifiedOverrides != null)
+                        {
+                            ApplyUnifiedOverrides(deviceConfiguration, unifiedOverrides);
+                        }
+                        var hsmInstance = new HenkF16HSIBoard1HardwareSupportModule(deviceConfiguration, legacyPath, unifiedPath);
                         toReturn.Add(hsmInstance);
                     }
                 }
@@ -136,6 +167,159 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board1
             }
 
             return toReturn.ToArray();
+        }
+
+        // Per-channel override bag returned by TryLoadUnifiedOverrides.
+        // Each entry is null when the unified file doesn't supply that
+        // channel, or a CalibrationPoint[] otherwise. Bundling the five
+        // channels into a single struct lets ApplyUnifiedOverrides /
+        // ReloadCalibration each touch the legacy device-config in one
+        // place rather than five.
+        private class UnifiedOverrides
+        {
+            public CalibrationPoint[] Heading;
+            public CalibrationPoint[] Bearing;
+            public CalibrationPoint[] RangeOnesDigit;
+            public CalibrationPoint[] RangeTensDigit;
+            public CalibrationPoint[] RangeHundredsDigit;
+        }
+
+        private static UnifiedOverrides TryLoadUnifiedOverrides(string unifiedPath)
+        {
+            try
+            {
+                if (!File.Exists(unifiedPath)) return null;
+                var unified = GaugeCalibrationConfig.Load<HenkF16HSIBoard1CalibrationConfig>(unifiedPath);
+                if (unified == null) return null;
+                var result = new UnifiedOverrides
+                {
+                    Heading            = ExtractChannelBreakpoints(unified, "Henk_F16_HSI_Board1_Magnetic_Heading_To_Instrument"),
+                    Bearing            = ExtractChannelBreakpoints(unified, "Henk_F16_HSI_Board1_Bearing_To_Instrument"),
+                    RangeOnesDigit     = ExtractChannelBreakpoints(unified, "Henk_F16_HSI_Board1_Range_x1_To_Instrument"),
+                    RangeTensDigit     = ExtractChannelBreakpoints(unified, "Henk_F16_HSI_Board1_Range_x10_To_Instrument"),
+                    RangeHundredsDigit = ExtractChannelBreakpoints(unified, "Henk_F16_HSI_Board1_Range_x100_To_Instrument"),
+                };
+                return result;
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Failed to load unified-schema calibration; falling back to legacy <*CalibrationData> blocks: " + e.Message);
+                return null;
+            }
+        }
+
+        private static CalibrationPoint[] ExtractChannelBreakpoints(GaugeCalibrationConfig config, string channelId)
+        {
+            var ch = config.FindChannel(channelId);
+            var bps = ch?.Transform?.Breakpoints;
+            if (bps == null || bps.Length < 2) return null;
+            // Editor writes <Point input=".." output=".."/> — both raw doubles.
+            var result = new CalibrationPoint[bps.Length];
+            for (var i = 0; i < bps.Length; i++)
+            {
+                result[i] = new CalibrationPoint(bps[i].Input, bps[i].Output);
+            }
+            return result;
+        }
+
+        // Apply non-null overrides onto the legacy device config in place.
+        // Null entries leave the legacy field untouched (so users can
+        // partially override — calibrate just heading from the editor and
+        // leave the range digits' existing legacy tables intact).
+        private static void ApplyUnifiedOverrides(DeviceConfig device, UnifiedOverrides overrides)
+        {
+            if (device == null || overrides == null) return;
+            if (overrides.Heading            != null) device.HeadingCalibrationData            = overrides.Heading;
+            if (overrides.Bearing            != null) device.BearingCalibrationData            = overrides.Bearing;
+            if (overrides.RangeOnesDigit     != null) device.RangeOnesDigitCalibrationData     = overrides.RangeOnesDigit;
+            if (overrides.RangeTensDigit     != null) device.RangeTensDigitCalibrationData     = overrides.RangeTensDigit;
+            if (overrides.RangeHundredsDigit != null) device.RangeHundredsDigitCalibrationData = overrides.RangeHundredsDigit;
+        }
+
+        // Watch both calibration files. Either changing triggers a reload
+        // of just the calibration tables — we never re-touch device identity
+        // / stator offsets / DIG_OUTs at runtime (those would require
+        // disconnecting and re-programming the hardware mid-flight). Same
+        // pattern as HenkieF16FuelFlowIndicatorHardwareSupportModule.
+        private void StartConfigWatchers()
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_legacyConfigPath))
+                {
+                    _legacyConfigWatcher = new ConfigFileReloadWatcher(_legacyConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+            try
+            {
+                if (!string.IsNullOrEmpty(_unifiedConfigPath))
+                {
+                    _unifiedConfigWatcher = new ConfigFileReloadWatcher(_unifiedConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+        }
+
+        // Re-evaluate the five calibration tables without touching the live
+        // device connection. Preference per channel: unified file's value
+        // when present (editor's source of truth); otherwise the legacy
+        // file's matching <*CalibrationData> block; otherwise the C#
+        // fallback math (= input range scaled linearly into 0..1023).
+        private void ReloadCalibration()
+        {
+            try
+            {
+                var unified = TryLoadUnifiedOverrides(_unifiedConfigPath);
+                CalibrationPoint[] heading            = unified?.Heading;
+                CalibrationPoint[] bearing            = unified?.Bearing;
+                CalibrationPoint[] rangeOnesDigit     = unified?.RangeOnesDigit;
+                CalibrationPoint[] rangeTensDigit     = unified?.RangeTensDigit;
+                CalibrationPoint[] rangeHundredsDigit = unified?.RangeHundredsDigit;
+
+                // For any channel the unified file didn't override, fall
+                // back to whatever the legacy file currently says (it may
+                // have been hand-edited since startup).
+                if ((heading == null || bearing == null || rangeOnesDigit == null
+                        || rangeTensDigit == null || rangeHundredsDigit == null)
+                    && !string.IsNullOrEmpty(_legacyConfigPath)
+                    && File.Exists(_legacyConfigPath))
+                {
+                    var legacy = HenkieF16HSIBoard1HardwareSupportModuleConfig.Load(_legacyConfigPath);
+                    var dev = legacy?.Devices?.FirstOrDefault(d =>
+                        d != null && string.Equals(d.Address, _hsiBoard1DeviceConfig?.Address, StringComparison.OrdinalIgnoreCase));
+                    if (dev != null)
+                    {
+                        if (heading            == null) heading            = dev.HeadingCalibrationData;
+                        if (bearing            == null) bearing            = dev.BearingCalibrationData;
+                        if (rangeOnesDigit     == null) rangeOnesDigit     = dev.RangeOnesDigitCalibrationData;
+                        if (rangeTensDigit     == null) rangeTensDigit     = dev.RangeTensDigitCalibrationData;
+                        if (rangeHundredsDigit == null) rangeHundredsDigit = dev.RangeHundredsDigitCalibrationData;
+                    }
+                }
+
+                // Atomic per-field replacement — the Calibrated*Value
+                // helpers read these fields directly, so partial updates
+                // are safe; the worst case is the next gauge tick using
+                // a mix of old + new which is no worse than the prior
+                // tick using all-old.
+                _headingCalibrationData            = heading            ?? _headingCalibrationData;
+                _bearingCalibrationData            = bearing            ?? _bearingCalibrationData;
+                _rangeOnesDigitCalibrationData     = rangeOnesDigit     ?? _rangeOnesDigitCalibrationData;
+                _rangeTensDigitCalibrationData     = rangeTensDigit     ?? _rangeTensDigitCalibrationData;
+                _rangeHundredsDigitCalibrationData = rangeHundredsDigit ?? _rangeHundredsDigitCalibrationData;
+
+                // Re-fire every Update*OutputValue with the cached input
+                // values so the user sees new calibration immediately,
+                // without waiting for the next sim tick.
+                UpdateMagneticHeadingOutputValue();
+                UpdateBearingOutputValue();
+                UpdateRangeOutputValue();
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Calibration reload failed; keeping previous tables: " + e.Message);
+            }
         }
 
         private List<DigitalSignal> CreateOutputSignalsForDigitalOutputChannels()
@@ -1298,6 +1482,16 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board1
                 {
                     UnregisterForEvents();
                     Common.Util.DisposeObject(_renderer);
+                    if (_legacyConfigWatcher != null)
+                    {
+                        try { _legacyConfigWatcher.Dispose(); } catch { }
+                        _legacyConfigWatcher = null;
+                    }
+                    if (_unifiedConfigWatcher != null)
+                    {
+                        try { _unifiedConfigWatcher.Dispose(); } catch { }
+                        _unifiedConfigWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;

--- a/src/SimLinkup/HardwareSupport/Henk/HSI/Board2/HenkF16HSIBoard2CalibrationConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/HSI/Board2/HenkF16HSIBoard2CalibrationConfig.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
+{
+    // Unified-schema calibration config for the Henk F-16 HSI Board 2,
+    // authored by the SimLinkup Profile Editor.
+    //
+    // This file lives ALONGSIDE the legacy
+    // HenkF16HSIBoard2HardwareSupportModule.config — same split-file
+    // contract as Board 1. The legacy file owns identity / stator
+    // offsets / hysteresis thresholds / DIG_OUTs; this file owns the
+    // single course-deviation breakpoint table.
+    //
+    // Filename: HenkF16HSIBoard2Calibration.config — distinct from the
+    // legacy HenkF16HSIBoard2HardwareSupportModule.config.
+    //
+    // One overridable channel:
+    //   - Henk_F16_HSI_Board2_Course_Deviation_Indicator_Position_To_Instrument
+    //     (input is normalized deviation -1..+1 = courseDeviationDegrees /
+    //     courseDeviationLimitDegrees; output is DAC counts 0..1023)
+    //
+    // Editor-side counterpart: src/js/gauges/henk-hsi-board2.js +
+    // src/js/gauge-config-io.js's GAUGE_CONFIG_FILENAME_OVERRIDES.
+    [Serializable]
+    [XmlRoot("HenkF16HSIBoard2Calibration")]
+    public class HenkF16HSIBoard2CalibrationConfig : GaugeCalibrationConfig
+    {
+    }
+}

--- a/src/SimLinkup/HardwareSupport/Henk/HSI/Board2/HenkF16HSIBoard2HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/HSI/Board2/HenkF16HSIBoard2HardwareSupportModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16.HSI;
 using Henkie.HSI.Board2;
@@ -51,9 +52,21 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
 
         private CalibrationPoint[] _courseDeviationIndicatorCalibrationData;
 
-        private HenkF16HSIBoard2HardwareSupportModule(DeviceConfig hsiBoard2DeviceConfig)
+        // Editor-authored calibration plumbing — see Board 1's matching
+        // fields for the contract. Board 2's unified file owns just the
+        // single course-deviation-indicator breakpoint table; everything
+        // else (identity, stator offsets, hysteresis thresholds,
+        // DIG_OUTs) stays in the legacy file.
+        private string _legacyConfigPath;
+        private string _unifiedConfigPath;
+        private ConfigFileReloadWatcher _legacyConfigWatcher;
+        private ConfigFileReloadWatcher _unifiedConfigWatcher;
+
+        private HenkF16HSIBoard2HardwareSupportModule(DeviceConfig hsiBoard2DeviceConfig, string legacyConfigPath, string unifiedConfigPath)
         {
             _hsiBoard2DeviceConfig = hsiBoard2DeviceConfig;
+            _legacyConfigPath = legacyConfigPath;
+            _unifiedConfigPath = unifiedConfigPath;
             if (_hsiBoard2DeviceConfig != null)
             {
                 ConfigureDevice();
@@ -61,6 +74,7 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
                 CreateOutputSignals();
                 RegisterForEvents();
                 SetInitialState();
+                StartConfigWatchers();
             }
         }
 
@@ -118,13 +132,26 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
 
             try
             {
-                var hsmConfigFilePath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard2HardwareSupportModule.config");
-                var hsmConfig = HenkieF16HSIBoard2HardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                var legacyPath  = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard2HardwareSupportModule.config");
+                var unifiedPath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkF16HSIBoard2Calibration.config");
+                var hsmConfig = HenkieF16HSIBoard2HardwareSupportModuleConfig.Load(legacyPath);
+
+                // Try the unified-schema calibration file (authored by the
+                // SimLinkup Profile Editor). When present, its single
+                // breakpoint table overrides the legacy file's
+                // <CourseDeviationIndicatorCalibrationData> block. See
+                // HenkF16HSIBoard2CalibrationConfig.cs for the rationale.
+                var unifiedCalibration = TryLoadUnifiedCalibration(unifiedPath);
+
                 if (hsmConfig != null)
                 {
                     foreach (var deviceConfiguration in hsmConfig.Devices)
                     {
-                        var hsmInstance = new HenkF16HSIBoard2HardwareSupportModule(deviceConfiguration);
+                        if (unifiedCalibration != null)
+                        {
+                            deviceConfiguration.CourseDeviationIndicatorCalibrationData = unifiedCalibration;
+                        }
+                        var hsmInstance = new HenkF16HSIBoard2HardwareSupportModule(deviceConfiguration, legacyPath, unifiedPath);
                         toReturn.Add(hsmInstance);
                     }
                 }
@@ -135,6 +162,93 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
             }
 
             return toReturn.ToArray();
+        }
+
+        // Load + map the unified-schema calibration file's course-deviation
+        // breakpoints onto Henkie.Common.CalibrationPoint. Returns null when
+        // the file is absent, malformed, or doesn't contain the expected
+        // channel — caller falls back to the legacy <CourseDeviation
+        // IndicatorCalibrationData> block.
+        private static CalibrationPoint[] TryLoadUnifiedCalibration(string unifiedPath)
+        {
+            try
+            {
+                if (!File.Exists(unifiedPath)) return null;
+                var unified = GaugeCalibrationConfig.Load<HenkF16HSIBoard2CalibrationConfig>(unifiedPath);
+                if (unified == null) return null;
+                var ch = unified.FindChannel("Henk_F16_HSI_Board2_Course_Deviation_Indicator_Position_To_Instrument");
+                var bps = ch?.Transform?.Breakpoints;
+                if (bps == null || bps.Length < 2) return null;
+                var result = new CalibrationPoint[bps.Length];
+                for (var i = 0; i < bps.Length; i++)
+                {
+                    result[i] = new CalibrationPoint(bps[i].Input, bps[i].Output);
+                }
+                return result;
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Failed to load unified-schema calibration; falling back to legacy <CourseDeviationIndicatorCalibrationData>: " + e.Message);
+                return null;
+            }
+        }
+
+        // Watch both calibration files. Either changing triggers a reload
+        // of just the calibration table — same pattern as Board 1 / FuelFlow.
+        private void StartConfigWatchers()
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_legacyConfigPath))
+                {
+                    _legacyConfigWatcher = new ConfigFileReloadWatcher(_legacyConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+            try
+            {
+                if (!string.IsNullOrEmpty(_unifiedConfigPath))
+                {
+                    _unifiedConfigWatcher = new ConfigFileReloadWatcher(_unifiedConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+        }
+
+        // Re-evaluate the course-deviation calibration without touching the
+        // live device connection. Preference: unified file's value when
+        // present (editor's source of truth); otherwise the legacy file's
+        // <CourseDeviationIndicatorCalibrationData> block.
+        private void ReloadCalibration()
+        {
+            CalibrationPoint[] next = null;
+            try
+            {
+                next = TryLoadUnifiedCalibration(_unifiedConfigPath);
+                if (next == null && !string.IsNullOrEmpty(_legacyConfigPath) && File.Exists(_legacyConfigPath))
+                {
+                    var legacy = HenkieF16HSIBoard2HardwareSupportModuleConfig.Load(_legacyConfigPath);
+                    var dev = legacy?.Devices?.FirstOrDefault(d =>
+                        d != null && string.Equals(d.Address, _hsiBoard2DeviceConfig?.Address, StringComparison.OrdinalIgnoreCase));
+                    if (dev?.CourseDeviationIndicatorCalibrationData != null
+                        && dev.CourseDeviationIndicatorCalibrationData.Length >= 2)
+                    {
+                        next = dev.CourseDeviationIndicatorCalibrationData;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Calibration reload failed; keeping previous table: " + e.Message);
+                return;
+            }
+            if (next != null && next.Length >= 2)
+            {
+                _courseDeviationIndicatorCalibrationData = next;
+                // Re-fire the course-deviation update with the cached input
+                // values so the user sees new calibration immediately.
+                CourseDeviationOrCourseDeviationLimitInputSignalsChanged();
+            }
         }
 
         private List<DigitalSignal> CreateOutputSignalsForDigitalOutputChannels()
@@ -987,6 +1101,16 @@ namespace SimLinkup.HardwareSupport.Henk.HSI.Board2
                 {
                     UnregisterForEvents();
                     Common.Util.DisposeObject(_renderer);
+                    if (_legacyConfigWatcher != null)
+                    {
+                        try { _legacyConfigWatcher.Dispose(); } catch { }
+                        _legacyConfigWatcher = null;
+                    }
+                    if (_unifiedConfigWatcher != null)
+                    {
+                        try { _unifiedConfigWatcher.Dispose(); } catch { }
+                        _unifiedConfigWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -153,8 +153,10 @@
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModule.cs" />
+    <Compile Include="HardwareSupport\Henk\HSI\Board1\HenkF16HSIBoard1CalibrationConfig.cs" />
     <Compile Include="HardwareSupport\Henk\HSI\Board1\HenkF16HSIBoard1HardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\HSI\Board1\HenkF16HSIBoard1HardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Henk\HSI\Board2\HenkF16HSIBoard2CalibrationConfig.cs" />
     <Compile Include="HardwareSupport\Henk\HSI\Board2\HenkF16HSIBoard2HardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\HSI\Board2\HenkF16HSIBoard2HardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\QuadSinCos\HenkieQuadSinCosBoardHardwareSupportModuleConfig.cs" />


### PR DESCRIPTION
## Summary

Wires both Henk F-16 HSI boards into the unified gauge-config schema so users can calibrate them from the SimLinkup Profile Editor's Calibration tab. Same split-file contract as **#22 (HenkieF16FuelFlow)** — calibration tables move to a new file alongside the existing legacy file, which continues to own everything that's not the breakpoint tables (identity, stator offsets, DIG_OUT initial values, hysteresis thresholds).

## Channels

**Board 1** — five overridable channels (all piecewise tables driving DAC counts to the synchro stators on the indicator):

| Channel id | Input | Output |
|---|---|---|
| `Henk_F16_HSI_Board1_Magnetic_Heading_To_Instrument` | 0..360° | 0..1023 |
| `Henk_F16_HSI_Board1_Bearing_To_Instrument` | 0..360° | 0..1023 |
| `Henk_F16_HSI_Board1_Range_x100_To_Instrument` | digit 0..10 | 0..1023 |
| `Henk_F16_HSI_Board1_Range_x10_To_Instrument` | digit 0..10 | 0..1023 |
| `Henk_F16_HSI_Board1_Range_x1_To_Instrument` | digit 0..10 | 0..1023 |

**Board 2** — one overridable channel:

| Channel id | Input | Output |
|---|---|---|
| `Henk_F16_HSI_Board2_Course_Deviation_Indicator_Position_To_Instrument` | normalized -1..+1 | 0..1023 |

(Board 2 normalizes course deviation as `degrees / limit` upstream of the calibration table — the input is unitless, symmetric around zero. That's why the table is symmetric -1→0, 0→511.5, +1→1023 vs Board 1's 0..360° asymmetric tables.)

Defaults match the C# fallback math in each board's `Calibrated*Value` helper, so a profile without a unified file (or one shipping defaults) sees zero behaviour change.

## Filenames

| File | Owns |
|---|---|
| `HenkF16HSIBoard1HardwareSupportModule.config` (legacy) | identity, stator offsets, DIG_OUT initial values |
| `HenkF16HSIBoard1Calibration.config` (NEW, editor-authored) | the 5 breakpoint tables |
| `HenkF16HSIBoard2HardwareSupportModule.config` (legacy) | identity, stator offsets, DIG_OUTs, hysteresis thresholds |
| `HenkF16HSIBoard2Calibration.config` (NEW, editor-authored) | the 1 breakpoint table |

Distinct names avoid collision with the editor's filename auto-derivation (which would otherwise overwrite the legacy file).

## HSM changes per board

- Constructor signature gains `(legacyConfigPath, unifiedConfigPath)` so the watcher knows which files to track.
- `GetInstances` loads the unified file via `GaugeCalibrationConfig.Load<>()` and applies non-null per-channel overrides onto the legacy device config in place. Null entries leave the legacy field untouched (partial overrides are supported — calibrate just heading from the editor and leave the range tables intact).
- Two `ConfigFileReloadWatcher`s (legacy + unified) invoke `ReloadCalibration` on either file's change. Reload re-resolves the per-channel arrays with the same precedence (unified wins, legacy fallback, C# math fallback) and re-fires the matching `Update*OutputValue` methods so users see new values within a few seconds without waiting for the next sim tick.
- `Dispose` cleans up both watchers.

## New files

- `HenkF16HSIBoard1CalibrationConfig.cs`
- `HenkF16HSIBoard2CalibrationConfig.cs`

Both thin subclasses of `GaugeCalibrationConfig` with matching `XmlRoot`.

## Test plan

- [x] Builds clean off `master` (Debug)
- [x] Profile WITHOUT either unified file: HSMs behave exactly as today (legacy `*CalibrationData` from the legacy file, OR the C# linear-fallback math when the legacy file's calibration block is also absent)
- [ ] Profile WITH a default unified file (round-trip from editor save): outputs identical to no-file path
- [ ] Edit a heading breakpoint; reload; HSM picks up new value mid-flight
- [ ] Hand-edit BOTH the legacy file's `<HeadingCalibrationData>` AND the unified file's heading channel; expect the unified file to win (matches FuelFlow's documented contract)
- [ ] Partial override: unified file with only one channel; legacy file still wins for the other four

🤖 Generated with [Claude Code](https://claude.com/claude-code)