### PR TITLE
HenkieF16Altimeter: editor-authored calibration

### DIFF
--- a/src/SimLinkup/HardwareSupport/Henk/Altimeter/HenkieF16AltimeterHardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/Altimeter/HenkieF16AltimeterHardwareSupportModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.Remoting;
 using Common.HardwareSupport;
+using Common.HardwareSupport.Calibration;
 using Common.MacroProgramming;
 using LightningGauges.Renderers.F16;
 using System.IO;
@@ -38,15 +39,34 @@ namespace SimLinkup.HardwareSupport.Henk.Altimeter
         private double _maxBaroPressure = DEFAULT_MAX_BARO_PRESSURE;
         private double _differenceInIndicatedAltitudeFromMinBaroToMaxBaroInFeet = DEFAULT_DIFFERENCE_IN_INDICATED_ALTITUDE_FROM_MIN_BARO_TO_MAX_BARO_IN_FEET;
         private CalibrationPoint[] _calibrationData;
-        private HenkieF16AltimeterHardwareSupportModule(DeviceConfig deviceConfig)
+
+        // Editor-authored calibration plumbing — same split-file contract
+        // as HenkieF16FuelFlow / HenkF16HSIBoard1 / HenkF16HSIBoard2:
+        // the legacy file (HenkieF16Altimeter.config) continues to own
+        // identity, stator base angles, DIG_OUT initial values, and the
+        // baro-compensation triangle (Min/Max BaroPressureInHg +
+        // IndicatedAltitudeDifference); the unified file
+        // (HenkieF16AltimeterHardwareSupportModule.config) carries the
+        // editor-authored breakpoint table that, when present, overrides
+        // the legacy file's <CalibrationData> block. See
+        // HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs.
+        private string _legacyConfigPath;
+        private string _unifiedConfigPath;
+        private ConfigFileReloadWatcher _legacyConfigWatcher;
+        private ConfigFileReloadWatcher _unifiedConfigWatcher;
+
+        private HenkieF16AltimeterHardwareSupportModule(DeviceConfig deviceConfig, string legacyConfigPath, string unifiedConfigPath)
         {
             _deviceConfig = deviceConfig;
+            _legacyConfigPath = legacyConfigPath;
+            _unifiedConfigPath = unifiedConfigPath;
             if (_deviceConfig != null)
             {
                 ConfigureDevice();
                 CreateInputSignals();
                 CreateOutputSignals();
                 RegisterForEvents();
+                StartConfigWatchers();
             }
 
         }
@@ -102,13 +122,27 @@ namespace SimLinkup.HardwareSupport.Henk.Altimeter
 
             try
             {
-                var hsmConfigFilePath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16Altimeter.config");
-                var hsmConfig = HenkieF16AltimeterHardwareSupportModuleConfig.Load(hsmConfigFilePath);
+                var legacyPath  = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16Altimeter.config");
+                var unifiedPath = Path.Combine(Util.CurrentMappingProfileDirectory, "HenkieF16AltimeterHardwareSupportModule.config");
+                var hsmConfig = HenkieF16AltimeterHardwareSupportModuleConfig.Load(legacyPath);
+
+                // Try the unified-schema calibration file (authored by the
+                // SimLinkup Profile Editor). When present, its single
+                // breakpoint table overrides the legacy file's
+                // <CalibrationData> block. See
+                // HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs
+                // for the rationale.
+                var unifiedCalibration = TryLoadUnifiedCalibration(unifiedPath);
+
                 if (hsmConfig != null)
                 {
                     foreach (var deviceConfiguration in hsmConfig.Devices)
                     {
-                        var hsmInstance = new HenkieF16AltimeterHardwareSupportModule(deviceConfiguration);
+                        if (unifiedCalibration != null)
+                        {
+                            deviceConfiguration.CalibrationData = unifiedCalibration;
+                        }
+                        var hsmInstance = new HenkieF16AltimeterHardwareSupportModule(deviceConfiguration, legacyPath, unifiedPath);
                         toReturn.Add(hsmInstance);
                     }
                 }
@@ -119,6 +153,94 @@ namespace SimLinkup.HardwareSupport.Henk.Altimeter
             }
 
             return toReturn.ToArray();
+        }
+
+        // Load + map the unified-schema calibration file's breakpoints onto
+        // Henkie.Common.CalibrationPoint. Returns null when the file is
+        // absent, malformed, or doesn't contain the expected channel — caller
+        // falls back to whatever's already on deviceConfiguration.CalibrationData
+        // (typically the legacy <CalibrationData> block).
+        private static CalibrationPoint[] TryLoadUnifiedCalibration(string unifiedPath)
+        {
+            try
+            {
+                if (!File.Exists(unifiedPath)) return null;
+                var unified = GaugeCalibrationConfig.Load<HenkieF16AltimeterUnifiedHardwareSupportModuleConfig>(unifiedPath);
+                if (unified == null) return null;
+                var ch = unified.FindChannel("HenkieF16Altimeter_Indicator_Position_To_Instrument");
+                var bps = ch?.Transform?.Breakpoints;
+                if (bps == null || bps.Length < 2) return null;
+                var result = new CalibrationPoint[bps.Length];
+                for (var i = 0; i < bps.Length; i++)
+                {
+                    result[i] = new CalibrationPoint(bps[i].Input, bps[i].Output);
+                }
+                return result;
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Failed to load unified-schema calibration; falling back to legacy <CalibrationData>: " + e.Message);
+                return null;
+            }
+        }
+
+        // Watch both calibration files. Either changing triggers a reload
+        // of just the calibration table — same pattern as Board 1/Board 2/
+        // FuelFlow. Stator base angles, baro-compensation triangle, and
+        // device identity stay untouched at runtime.
+        private void StartConfigWatchers()
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_legacyConfigPath))
+                {
+                    _legacyConfigWatcher = new ConfigFileReloadWatcher(_legacyConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+            try
+            {
+                if (!string.IsNullOrEmpty(_unifiedConfigPath))
+                {
+                    _unifiedConfigWatcher = new ConfigFileReloadWatcher(_unifiedConfigPath, ReloadCalibration);
+                }
+            }
+            catch (Exception e) { Log.Error(e.Message, e); }
+        }
+
+        // Re-evaluate the calibration table without touching the live
+        // device connection. Preference: unified file when present
+        // (editor's source of truth); otherwise the legacy file's
+        // <CalibrationData> block.
+        private void ReloadCalibration()
+        {
+            CalibrationPoint[] next = null;
+            try
+            {
+                next = TryLoadUnifiedCalibration(_unifiedConfigPath);
+                if (next == null && !string.IsNullOrEmpty(_legacyConfigPath) && File.Exists(_legacyConfigPath))
+                {
+                    var legacy = HenkieF16AltimeterHardwareSupportModuleConfig.Load(_legacyConfigPath);
+                    var dev = legacy?.Devices?.FirstOrDefault(d =>
+                        d != null && string.Equals(d.Address, _deviceConfig?.Address, StringComparison.OrdinalIgnoreCase));
+                    if (dev?.CalibrationData != null && dev.CalibrationData.Length >= 2)
+                    {
+                        next = dev.CalibrationData;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Calibration reload failed; keeping previous table: " + e.Message);
+                return;
+            }
+            if (next != null && next.Length >= 2)
+            {
+                _calibrationData = next;
+                // Re-fire the altitude update with the cached input values so
+                // the user sees new calibration immediately.
+                UpdateAltitudeOutputValues();
+            }
         }
 
         private static int ChannelNumber(OutputChannels outputChannel)
@@ -491,6 +613,16 @@ namespace SimLinkup.HardwareSupport.Henk.Altimeter
                     UnregisterForEvents();
                     Common.Util.DisposeObject(_altimeterDeviceInterface);
                     Common.Util.DisposeObject(_renderer);
+                    if (_legacyConfigWatcher != null)
+                    {
+                        try { _legacyConfigWatcher.Dispose(); } catch { }
+                        _legacyConfigWatcher = null;
+                    }
+                    if (_unifiedConfigWatcher != null)
+                    {
+                        try { _unifiedConfigWatcher.Dispose(); } catch { }
+                        _unifiedConfigWatcher = null;
+                    }
                 }
             }
             _isDisposed = true;

--- a/src/SimLinkup/HardwareSupport/Henk/Altimeter/HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/Altimeter/HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Xml.Serialization;
+using Common.HardwareSupport.Calibration;
+
+namespace SimLinkup.HardwareSupport.Henk.Altimeter
+{
+    // Unified-schema calibration config for the Henkie F-16 altimeter
+    // drive board, authored by the SimLinkup Profile Editor.
+    //
+    // This file lives ALONGSIDE the legacy HenkieF16Altimeter.config
+    // (distinct filename, no collision). The legacy file continues to
+    // own everything that's not the calibration table:
+    //   - Address, COMPort, ConnectionType, DiagnosticLEDMode
+    //   - StatorBaseAnglesConfig (S1/S2/S3 base angles)
+    //   - OutputChannelsConfig (DIG_OUT_1/2/3 initial values)
+    //   - MinBaroPressureInHg / MaxBaroPressureInHg /
+    //     IndicatedAltitudeDifferenceInFeetFromMinBaroToMaxBaro (the
+    //     baro-compensation triangle that biases altitude before the
+    //     calibration table is consulted)
+    //
+    // The unified file owns just the input→DAC breakpoint table, in the
+    // editor's standard <Channels>/<Transform kind="piecewise"> shape.
+    //
+    // Filename: HenkieF16AltimeterHardwareSupportModule.config — matches
+    // the editor's filename auto-derivation from the gauge's `cls`
+    // (SimLinkup.HardwareSupport.Henk.Altimeter.HenkieF16Altimeter
+    // HardwareSupportModule). Distinct from the legacy
+    // HenkieF16Altimeter.config so no override is needed in the editor's
+    // GAUGE_CONFIG_FILENAME_OVERRIDES.
+    //
+    // One overridable channel:
+    //   - HenkieF16Altimeter_Indicator_Position_To_Instrument
+    //     (input is altitude mod 10000 ft after baro compensation;
+    //     output is DAC counts 0..4095 driving the synchro stator)
+    //
+    // Editor-side counterpart: src/js/gauges/henkie-altimeter.js.
+    [Serializable]
+    [XmlRoot("HenkieF16AltimeterHardwareSupportModule")]
+    public class HenkieF16AltimeterUnifiedHardwareSupportModuleConfig : GaugeCalibrationConfig
+    {
+    }
+}

--- a/src/SimLinkup/SimLinkup.csproj
+++ b/src/SimLinkup/SimLinkup.csproj
@@ -150,6 +150,7 @@
     <Compile Include="HardwareSupport\Henk\ADI\HenkF16ADISupportBoardHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModule.cs" />
     <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterHardwareSupportModuleConfig.cs" />
+    <Compile Include="HardwareSupport\Henk\Altimeter\HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModuleConfig.cs" />
     <Compile Include="HardwareSupport\Henk\FuelFlow\HenkieF16FuelFlowIndicatorHardwareSupportModule.cs" />


### PR DESCRIPTION
## Summary

Wires the Henkie F-16 altimeter drive board into the unified gauge-config schema so users can calibrate it from the SimLinkup Profile Editor's Calibration tab.

## Channel

| Channel id | Input | Output |
|---|---|---|
| `HenkieF16Altimeter_Indicator_Position_To_Instrument` | altitude mod 10000 ft (post-baro-comp) | DAC counts 0..4095 |

Defaults match the C# fallback math in `CalibratedPosition` (linear 0..10000 ft → 0..4095 DAC), so a profile without a unified file (or one shipping defaults) sees zero behaviour change.

## Why baro compensation isn't in the editor

The legacy `MinBaroPressureInHg` / `MaxBaroPressureInHg` / `IndicatedAltitudeDifferenceInFeetFromMinBaroToMaxBaro` triangle biases altitude **upstream** of the calibration table. Those three fields stay in the legacy file because:

1. They're per-installation tuning that rarely changes after bench-up.
2. The calibration table only ever sees post-baro-compensated altitude — it can't observe or affect baro behaviour, so editing the table doesn't need a baro context.
3. Splitting them into the unified schema would muddy the editor's "one breakpoint table per channel" mental model.

## Filenames

| File | Owns |
|---|---|
| `HenkieF16Altimeter.config` (legacy) | identity, stator base angles, DIG_OUT initial values, baro-compensation triangle |
| `HenkieF16AltimeterHardwareSupportModule.config` (NEW, editor-authored) | the single calibration breakpoint table |

The unified file uses the editor's auto-derived filename (gauge `cls` ends with `HenkieF16AltimeterHardwareSupportModule`), so no entry is needed in the editor's `GAUGE_CONFIG_FILENAME_OVERRIDES`. Distinct from the legacy `HenkieF16Altimeter.config` so no collision.

## HSM changes

- Constructor signature gains `(legacyConfigPath, unifiedConfigPath)`.
- `GetInstances` loads the unified file via `GaugeCalibrationConfig.Load<>()` and overrides `deviceConfiguration.CalibrationData` when the unified file's breakpoint table is present.
- Two `ConfigFileReloadWatcher`s (legacy + unified) invoke `ReloadCalibration` on either file's change. Reload re-resolves with the same precedence (unified wins, legacy fallback) and re-fires `UpdateAltitudeOutputValues` with cached input values so users see new calibration within seconds.
- `Dispose` cleans up both watchers.

## New file

`HenkieF16AltimeterUnifiedHardwareSupportModuleConfig.cs` — thin subclass of `GaugeCalibrationConfig` with matching `XmlRoot`.

## Test plan

- [x] Builds clean off `master` (Debug)
- [x] Profile WITHOUT the unified file: HSM behaves exactly as today (legacy `<CalibrationData>` from the legacy file, OR the C# linear-fallback math when the legacy file's calibration block is absent)
- [ ] Profile WITH a default unified file (round-trip from editor save): outputs identical to no-file path
- [ ] Edit a breakpoint; reload; HSM picks up new value mid-flight (re-fire of `UpdateAltitudeOutputValues`)
- [ ] Hand-edit BOTH the legacy file's `<CalibrationData>` AND the unified file's breakpoint table; expect the unified file to win (matches FuelFlow / HSI documented contract)
- [ ] Change baro pressure input; expect the same calibration table value to apply at the new post-baro-comp altitude

## Pattern

This is the fourth Henk gauge to follow the split-file contract:

- #22 HenkieF16FuelFlow
- #26 HenkF16HSIBoard1 + HenkF16HSIBoard2
- This PR — HenkieF16Altimeter

After this lands, every Henk gauge in the tree has editor-authored calibration support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)