### PR TITLE
GaugeCalibrationConfig: EvaluatePiecewise honors Output, not just Volts

### DIFF
--- a/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
+++ b/src/Common/HardwareSupport/Calibration/GaugeCalibrationConfig.cs
@@ -393,9 +393,9 @@ namespace Common.HardwareSupport.Calibration
             // channel runs 140..700 (DAC counts), well outside ±10. Letting
             // the math run and clamping at the per-channel boundary is the
             // correct, gauge-agnostic shape.
-            if (input <= breakpoints[0].Input) return breakpoints[0].Volts;
+            if (input <= breakpoints[0].Input) return BpValue(breakpoints[0]);
             var last = breakpoints[breakpoints.Length - 1];
-            if (input >= last.Input) return last.Volts;
+            if (input >= last.Input) return BpValue(last);
             for (var i = 1; i < breakpoints.Length; i++)
             {
                 var hi = breakpoints[i];
@@ -403,12 +403,28 @@ namespace Common.HardwareSupport.Calibration
                 {
                     var lo = breakpoints[i - 1];
                     var span = hi.Input - lo.Input;
-                    if (span <= 0) return lo.Volts;  // degenerate; pick the lower
+                    if (span <= 0) return BpValue(lo);  // degenerate; pick the lower
                     var t = (input - lo.Input) / span;
-                    return lo.Volts + t * (hi.Volts - lo.Volts);
+                    return BpValue(lo) + t * (BpValue(hi) - BpValue(lo));
                 }
             }
-            return last.Volts;
+            return BpValue(last);
+        }
+
+        // Pick the right output attribute off a breakpoint. Volts-based gauges
+        // (every Simtek + Lilbern + Westin + AMI + Astronautics today) author
+        // their breakpoints as <Point input=".." volts=".."/>, so Volts carries
+        // the value and Output deserializes to its default of 0. DAC-counts
+        // gauges (Henk F-16 ADI Support Board pitch/roll/command bars/RoT)
+        // author as <Point input=".." output=".."/>, so Output carries the
+        // value and Volts is 0. Prefer Output when present, fall back to Volts.
+        // Edge case where both happen to be 0 (a legitimate zero-volts knot in
+        // a Simtek table) collapses cleanly: both interpretations give 0.
+        // Without this dispatch, EvaluatePiecewise silently returned 0 for
+        // every DAC-counts breakpoint, parking the gauge at its MinValue rail.
+        private static double BpValue(GaugeBreakpoint bp)
+        {
+            return bp.Output != 0 ? bp.Output : bp.Volts;
         }
 
         // Resolver pair: maps `input` linearly to an angle in


### PR DESCRIPTION
## Summary

- `GaugeBreakpoint` deserializes both `volts=` and `output=` XML attributes into separate fields (`Volts` and `Output`).
- `GaugeTransform.EvaluatePiecewise` was reading only `.Volts`, so DAC-counts breakpoints (Henk F-16 ADI Support Board pitch/roll/command bars/rate-of-turn — all authored as `output=` in the editor-authored config) were silently interpreted as 0 V.
- Net effect on the user's gauge: at every input value the helper returned 0, `ApplyTrim` clamped to `MinValue`, and the synchro parked at its rail. On the F-16 ADI this surfaced as the ball showing the lower red overspeed area regardless of attitude — and deleting the config file restored correct behavior (the hardcoded fallback math doesn't touch this helper).
- Added a `BpValue(bp)` helper that prefers `Output` when non-zero, falls back to `Volts`.

## Why this is safe for existing gauges

Every other piecewise gauge (Simtek + AMI + Astronautics + Westin + Lilbern, both the Simtek Mach reference and AMI command bars, etc.) authors `<Point input=".." volts=".."/>`. Their `Output` deserializes to the `double` default of 0, so `BpValue` returns `Volts` unchanged.

The only behavior flip is on breakpoints that have `Output != 0` — which is precisely the broken case. Edge case where a breakpoint legitimately has `volts="0"` (e.g. an electrical-zero knot in a Simtek table) collapses cleanly: both `Volts` and `Output` are 0, so either interpretation gives 0.

## Test plan

- [ ] Build SimLinkup.sln in Release|x86.
- [ ] On a profile with a Henk F-16 ADI Support Board declared and an editor-authored `HenkF16ADISupportBoardHardwareSupportModule.config` on disk: pitch and roll inputs drive the synchro through its full range (140..700 for pitch, 0..1023 for roll) — not parked at MinValue.
- [ ] On a profile with Simtek + AnalogDevices (anything in `volts=` form): unchanged behavior — Simtek airspeed/altimeter/etc. continue to scale correctly with their editor-authored breakpoint tables.
- [ ] Delete the Henk ADI config file: hardcoded fallback (`424 + pitch/90 × 255`) still runs.