### PR TITLE
JDL-ADI01: Roll SIN output declared ±10 V to match COS partner

### DIFF
--- a/src/SimLinkup/HardwareSupport/Simtek/SimtekJDLADI01HardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Simtek/SimtekJDLADI01HardwareSupportModule.cs
@@ -753,14 +753,16 @@ namespace SimLinkup.HardwareSupport.Simtek
                 State = 0.00, //volts;
                 IsVoltage = true,
                 IsSine = true,
-                // NOTE: original C# declared MinValue/MaxValue as ±1 (not ±10)
-                // here, while the matching ROLL COS signal declares ±10. The
-                // ApplyTrim helper now clamps overrides to whichever bounds
-                // are declared, so preserving the original ±1 keeps existing
-                // behavior consistent. If a spec sheet later confirms this
-                // was a typo, change to ±10.
-                MinValue = -1,
-                MaxValue = 1
+                // ±10 V to match the matching ROLL COS signal. The original
+                // C# declared ±1 here, which clipped EvaluatePiecewiseResolver's
+                // sin output (which can swing the full ±peakVolts) and produced
+                // an imbalanced sin/cos pair — symptom on the bench was the
+                // roll synchro "skipping" past intermediate angles, hunting
+                // toward whichever (sin, cos) vector the clipped pair pointed
+                // at instead of the smooth interpolated angle. Fixed for
+                // brand-new gauges out of the box.
+                MinValue = -10,
+                MaxValue = 10
             };
             return thisSignal;
         }


### PR DESCRIPTION
## Summary

`CreateRollSinOutputSignal` declared `MinValue/MaxValue = ±1` while the matching `RollCos` / `PitchSin` / `PitchCos` all declare `±10`. `ApplyTrim` clamps to these declared bounds, so the roll SIN voltage was clipped to a 10× narrower range than its COS partner — producing an imbalanced sin/cos vector that didn't correspond to any real synchro angle.

On a brand-new factory-tested JDL-ADI01 this surfaced as roll "skipping very badly" while pitch was smooth as glass.

## Why now

A pre-existing comment in the code flagged this as suspect: *"original C# declared MinValue/MaxValue as ±1 (not ±10) here, while the matching ROLL COS signal declares ±10... If a spec sheet later confirms this was a typo, change to ±10."*

Spec confirmed: JDL F-16 ADI calibration sheets (Simtek WO 10-7840) show ROLL SIN swinging the full ±10 V at ±90° roll, same scale as every other resolver output on the gauge. The ±1 was a typo in the original C#.

## Test plan

- [ ] Build SimLinkup.sln in Release|x86. (Verified locally: succeeds, 0 errors.)
- [ ] On a profile with JDL-ADI01 declared, drive roll input through ±180°. The synchro should follow smoothly through the full range — no skipping between intermediate angles.
- [ ] Pitch behaviour unchanged (was already ±10 on both sin/cos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)