### PR TITLE
HenkieF16FuelFlow: re-drive gauge on calibration hot-reload

### DIFF
--- a/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowIndicatorHardwareSupportModule.cs
+++ b/src/SimLinkup/HardwareSupport/Henk/FuelFlow/HenkieF16FuelFlowIndicatorHardwareSupportModule.cs
@@ -251,6 +251,17 @@ namespace SimLinkup.HardwareSupport.Henk.FuelFlow
             if (next != null && next.Length >= 2)
             {
                 _calibrationData = next;
+                // Re-evaluate the current fuel-flow input with the new
+                // calibration table so the physical needle moves to the
+                // freshly-calibrated position immediately. Without this
+                // the gauge sat at whatever position was written before
+                // the reload, waiting for the next input-signal change
+                // (which won't come while BMS is closed during
+                // bench calibration). Mirrors the pattern used by
+                // Simtek100335015HardwareSupportModule.ReloadConfig,
+                // Simtek101084HardwareSupportModule.ReloadConfig, and
+                // HenkF16ADISupportBoardHardwareSupportModule.ReloadConfig.
+                UpdateFuelFlowOutputValues();
             }
         }
 


### PR DESCRIPTION
ReloadCalibration() updated _calibrationData but didn't recompute the current output value. During bench calibration the user opens the editor, edits a breakpoint, saves — the file changes on disk, the watcher fires, the table gets refreshed — but the physical needle sits at whatever position was last driven. Nothing moves until BMS opens and pushes a fresh fuel-flow input, which is exactly when the user DOESN'T want to be bench-calibrating.

Fix: call UpdateFuelFlowOutputValues() at the tail of ReloadCalibration so the cached input value re-flows through the new breakpoint table and lands on the hardware immediately. Mirrors the pattern in Simtek100335015HardwareSupportModule.ReloadConfig, Simtek101084HardwareSupportModule.ReloadConfig, and HenkF16ADISupportBoardHardwareSupportModule.ReloadConfig, all of which already re-invoke their Update*OutputValues methods on reload.

Verified: SimLinkup.sln builds Release|x86, 0 errors.